### PR TITLE
feat(pi-gateway): add Telegram sticker management tools

### DIFF
--- a/STICKER_TOOL_PR.md
+++ b/STICKER_TOOL_PR.md
@@ -1,0 +1,79 @@
+# PR: Add Sticker Tools to pi-gateway
+
+## Summary
+
+Add unified Telegram sticker pack management tools to pi-gateway.
+
+## Changes
+
+### New Files
+
+```
+src/tools/sticker.ts       # Unified tool definitions + implementation (12KB)
+src/tools/index.ts         # Export
+src/cli/sticker.ts         # CLI commands
+```
+
+### Modified Files
+
+```
+src/cli.ts                 # Add sticker command import + handler
+```
+
+## Usage
+
+### CLI
+
+```bash
+pi-gw sticker list <pack>                    # List stickers
+pi-gw sticker send <chat> <pack> [idx]       # Send sticker
+pi-gw sticker send <chat> <pack> random      # Send random
+pi-gw sticker download <pack> [dir]          # Download pack
+pi-gw sticker search <query>                 # Search packs
+```
+
+### Agent Tools
+
+```typescript
+// List pack
+sticker_list_pack({ packName: "LINE_HATSUNE_MIKU_Pom_Ver" })
+
+// Send sticker
+sticker_send({ chatId: "-5106685069", packName: "...", index: 1 })
+sticker_send({ chatId: "...", packName: "...", random: true })
+sticker_send({ chatId: "...", batch: [{packName: "...", index: 1}, ...] })
+
+// Download
+sticker_download_pack({ packName: "...", outputDir: "./dl" })
+
+// Search
+sticker_search_packs({ query: "miku", limit: 10 })
+```
+
+## Architecture
+
+```
+src/tools/sticker.ts (unified)
+├── Tool Definitions (stickerListPackTool, etc.)
+├── TelegramApi class
+├── StickerTools class
+│   ├── listPack()
+│   ├── send() / sendSingle() / sendBatch()
+│   ├── download()
+│   └── search()
+└── createStickerTools()
+```
+
+## Checklist
+
+- [x] Unified single-file implementation
+- [x] 4 tool definitions
+- [x] CLI commands
+- [x] Rate limiting (500ms)
+- [x] Error handling
+- [ ] Unit tests
+- [ ] Integration tests
+
+## Breaking Changes
+
+None.

--- a/cli.patch
+++ b/cli.patch
@@ -1,0 +1,34 @@
+diff --git a/pi-gateway/src/cli.ts b/pi-gateway/src/cli.ts
+index abc123..def456 100644
+--- a/pi-gateway/src/cli.ts
++++ b/pi-gateway/src/cli.ts
+@@ -45,6 +45,8 @@ import type {
+ import type { InboundMessage, SessionKey } from "./core/types.ts";
+ import type { DispatchResult } from "./gateway/types.ts";
+ import { createLogger } from "./core/types.ts";
+ import { ExecGuard } from "./core/exec-guard.ts";
++import { runSticker } from "./cli/sticker.ts";
+ 
+ // ============================================================================
+ // Argument Parsing
+@@ -534,6 +536,10 @@ function showHelp(): void {
+   pi-gw media clean [--days N] [--channel <ch>] [--dry-run]  Clean old media files
+   pi-gw media sticker-cache [stats|prune|clear]           Manage sticker cache
+   pi-gw install-daemon [--port N]                         Install as system daemon
++  pi-gw sticker list <pack>                             List stickers in pack
++  pi-gw sticker send <chat> <pack> [idx|random]         Send sticker to chat
++  pi-gw sticker download <pack> [dir]                   Download sticker pack
++  pi-gw sticker search <query>                          Search sticker packs
+   pi-gw uninstall-daemon                                  Remove system daemon
+   pi-gw help                                              Show this help
+   pi-gw <plugin-command> [...]                            Run plugin-registered CLI command
+@@ -571,6 +577,9 @@ switch (command) {
+   case "media":
+     await runMedia();
+     break;
++  case "sticker":
++    await runSticker(args, () => loadConfig(getArg("config")));
++    break;
+   case "install-daemon": {
+     const config = loadConfig(getArg("config"));
+     const port = getArg("port") ? parseInt(getArg("port")!, 10) : config.gateway.port;

--- a/pi-gateway/src/cli.ts
+++ b/pi-gateway/src/cli.ts
@@ -33,6 +33,7 @@ import type { InboundMessage, SessionKey } from "./core/types.ts";
 import type { DispatchResult } from "./gateway/types.ts";
 import { createLogger } from "./core/types.ts";
 import { ExecGuard } from "./core/exec-guard.ts";
+import { runSticker } from "./cli/sticker.ts";
 
 // ============================================================================
 // Argument Parsing
@@ -569,6 +570,10 @@ Usage:
   pi-gw media stats [--channel <ch>]                      Show media storage statistics
   pi-gw media clean [--days N] [--channel <ch>] [--dry-run]  Clean old media files
   pi-gw media sticker-cache [stats|prune|clear]           Manage sticker cache
+  pi-gw sticker list <pack>                               List stickers in pack
+  pi-gw sticker send <chat> <pack> [index|random]         Send sticker to chat
+  pi-gw sticker download <pack> [dir]                     Download sticker pack
+  pi-gw sticker search <query>                            Search sticker packs
   pi-gw install-daemon [--port N]                         Install as system daemon
   pi-gw uninstall-daemon                                  Remove system daemon
   pi-gw help                                              Show this help
@@ -602,6 +607,9 @@ switch (command) {
     break;
   case "media":
     await runMedia();
+    break;
+  case "sticker":
+    await runSticker(args, () => loadConfig(getArg("config")));
     break;
   case "install-daemon": {
     const config = loadConfig(getArg("config"));

--- a/pi-gateway/src/cli/sticker.ts
+++ b/pi-gateway/src/cli/sticker.ts
@@ -1,0 +1,120 @@
+/**
+ * Sticker CLI Commands
+ * 
+ * pi-gw sticker list <pack>
+ * pi-gw sticker send <chat> <pack> [index|random]
+ * pi-gw sticker download <pack> [dir]
+ * pi-gw sticker search <query>
+ */
+
+import { createStickerTools } from "../tools/index.ts";
+
+export async function runSticker(args: string[], getConfig: () => any): Promise<void> {
+  const sub = args[1];
+  const botToken = getConfig()?.channels?.telegram?.botToken;
+
+  if (!botToken) {
+    console.error("❌ Telegram bot token not configured");
+    process.exit(1);
+  }
+
+  const sticker = createStickerTools(botToken);
+
+  switch (sub) {
+    case "list": {
+      const packName = args[2];
+      if (!packName) {
+        console.error("Usage: pi-gw sticker list <pack_name>");
+        process.exit(1);
+      }
+
+      const info = await sticker.listPack(packName);
+      console.log(`\n📦 ${info.title}`);
+      console.log(`   Name: ${info.name} | Total: ${info.total}`);
+      console.log(`   Animated: ${info.contains_animated} | Video: ${info.contains_video}\n`);
+
+      info.stickers.slice(0, 20).forEach(s => {
+        const type = s.is_video ? "[video]" : s.is_animated ? "[anim]" : "[static]";
+        console.log(`  ${String(s.index).padStart(3)} ${type} ${s.emoji || ""}`);
+      });
+      if (info.stickers.length > 20) console.log(`  ... ${info.stickers.length - 20} more`);
+      console.log();
+      break;
+    }
+
+    case "send": {
+      const chatId = args[2];
+      const packName = args[3];
+      const idx = args[4] || "1";
+
+      if (!chatId || !packName) {
+        console.error("Usage: pi-gw sticker send <chat_id> <pack_name> [index|random]");
+        process.exit(1);
+      }
+
+      const isRandom = idx === "random";
+      const result = await sticker.send({
+        chatId,
+        packName,
+        index: isRandom ? undefined : parseInt(idx),
+        random: isRandom,
+      });
+
+      if (Array.isArray(result)) {
+        console.log(`✅ Sent ${result.filter(r => r.success).length}/${result.length}`);
+      } else if (result.success) {
+        console.log(`✅ Sticker sent!`);
+      } else {
+        console.error(`❌ ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case "download": {
+      const packName = args[2];
+      const outputDir = args[3];
+
+      if (!packName) {
+        console.error("Usage: pi-gw sticker download <pack_name> [output_dir]");
+        process.exit(1);
+      }
+
+      console.log(`⬇️  Downloading ${packName}...`);
+      const result = await sticker.download({ packName, outputDir });
+
+      if (result.success) {
+        console.log(`✅ Downloaded ${result.downloaded} to ${result.outputPath}`);
+        if (result.failed) console.log(`⚠️  Failed: ${result.failed}`);
+      } else {
+        console.error(`❌ ${result.error}`);
+        process.exit(1);
+      }
+      break;
+    }
+
+    case "search": {
+      const query = args[2];
+      if (!query) {
+        console.error("Usage: pi-gw sticker search <query>");
+        process.exit(1);
+      }
+
+      const results = await sticker.search(query, 10);
+      console.log(`\n🔍 ${results.length} packs found:\n`);
+      results.forEach((p, i) => {
+        console.log(`  ${i + 1}. ${p.title} (${p.stickerCount})`);
+        console.log(`     ${p.name}`);
+      });
+      console.log();
+      break;
+    }
+
+    default:
+      console.log("Usage:");
+      console.log("  pi-gw sticker list <pack>");
+      console.log("  pi-gw sticker send <chat> <pack> [idx|random]");
+      console.log("  pi-gw sticker download <pack> [dir]");
+      console.log("  pi-gw sticker search <query>");
+  }
+}

--- a/pi-gateway/src/tools/index.ts
+++ b/pi-gateway/src/tools/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Sticker Tools — Unified Export
+ */
+
+export {
+  // Tools
+  stickerListPackTool,
+  stickerSendTool,
+  stickerDownloadPackTool,
+  stickerSearchPacksTool,
+  // Implementation
+  StickerTools,
+  createStickerTools,
+  // Types
+  type StickerInfo,
+  type StickerPackInfo,
+  type StickerSendResult,
+  type StickerDownloadResult,
+} from "./sticker.ts";

--- a/pi-gateway/src/tools/sticker.ts
+++ b/pi-gateway/src/tools/sticker.ts
@@ -1,0 +1,336 @@
+/**
+ * Sticker Tools — Unified Implementation
+ * 
+ * All sticker-related tools in one file:
+ * - sticker_list_pack
+ * - sticker_send  
+ * - sticker_download_pack
+ * - sticker_search_packs
+ */
+
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import type { ToolDefinition } from "../plugins/types.ts";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface StickerInfo {
+  file_id: string;
+  file_unique_id: string;
+  index: number;
+  is_animated: boolean;
+  is_video: boolean;
+  emoji?: string;
+}
+
+export interface StickerPackInfo {
+  name: string;
+  title: string;
+  sticker_type: "regular" | "mask" | "custom_emoji";
+  contains_animated: boolean;
+  contains_video: boolean;
+  stickers: StickerInfo[];
+  total: number;
+}
+
+export interface StickerSendResult {
+  success: boolean;
+  messageId?: number;
+  error?: string;
+}
+
+export interface StickerDownloadResult {
+  success: boolean;
+  downloaded: number;
+  failed: number;
+  outputPath?: string;
+  files?: string[];
+  error?: string;
+}
+
+// =============================================================================
+// Telegram API Client
+// =============================================================================
+
+class TelegramApi {
+  private token: string;
+  private baseUrl: string;
+
+  constructor(token: string) {
+    this.token = token;
+    this.baseUrl = `https://api.telegram.org/bot${token}`;
+  }
+
+  async call(method: string, params?: Record<string, any>): Promise<any> {
+    const url = `${this.baseUrl}/${method}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+
+    const data = await res.json();
+    if (!data.ok) throw new Error(data.description);
+    return data.result;
+  }
+
+  getStickerSet = (name: string) => this.call("getStickerSet", { name });
+  sendSticker = (chatId: string | number, fileId: string) => 
+    this.call("sendSticker", { chat_id: chatId, sticker: fileId });
+  getFile = (fileId: string) => this.call("getFile", { file_id: fileId });
+  
+  async downloadFile(filePath: string): Promise<Uint8Array> {
+    const url = `https://api.telegram.org/file/bot${this.token}/${filePath}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+    return new Uint8Array(await res.arrayBuffer());
+  }
+}
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const stickerListPackTool: ToolDefinition = {
+  name: "sticker_list_pack",
+  description: `List all stickers in a Telegram sticker pack.
+
+Returns: pack name, title, total count, sticker types, file_ids for sending.`,
+  parameters: {
+    type: "object",
+    properties: {
+      packName: { type: "string", description: "Sticker pack name (from t.me/addstickers/<NAME>)" },
+    },
+    required: ["packName"],
+  },
+};
+
+export const stickerSendTool: ToolDefinition = {
+  name: "sticker_send",
+  description: `Send sticker(s) to a chat. Options: by index, random, or batch.`,
+  parameters: {
+    type: "object",
+    properties: {
+      chatId: { type: "string", description: "Target chat ID" },
+      packName: { type: "string", description: "Sticker pack name" },
+      index: { type: "number", description: "Sticker index (1-based)" },
+      fileId: { type: "string", description: "Direct file_id (optional)" },
+      random: { type: "boolean", description: "Send random sticker from pack" },
+      batch: { type: "array", description: "Batch: [{packName?, index?, fileId?}]" },
+      delayMs: { type: "number", description: "Delay between batch sends (ms)", default: 500 },
+    },
+    required: ["chatId"],
+  },
+};
+
+export const stickerDownloadPackTool: ToolDefinition = {
+  name: "sticker_download_pack",
+  description: `Download all stickers from a pack. Creates index.json with metadata.`,
+  parameters: {
+    type: "object",
+    properties: {
+      packName: { type: "string", description: "Sticker pack name" },
+      outputDir: { type: "string", description: "Output directory" },
+      limit: { type: "number", description: "Limit count (for testing)" },
+      createIndex: { type: "boolean", description: "Create index.json", default: true },
+    },
+    required: ["packName"],
+  },
+};
+
+export const stickerSearchPacksTool: ToolDefinition = {
+  name: "sticker_search_packs",
+  description: `Search popular sticker packs by keyword.`,
+  parameters: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "Search query (e.g., 'miku', 'anime')" },
+      limit: { type: "number", description: "Max results", default: 10 },
+    },
+    required: ["query"],
+  },
+};
+
+// =============================================================================
+// Tool Implementations
+// =============================================================================
+
+export class StickerTools {
+  private api: TelegramApi;
+  private defaultDelay = 500;
+
+  constructor(botToken: string) {
+    this.api = new TelegramApi(botToken);
+  }
+
+  // ---------------------------------------------------------------------------
+  // sticker_list_pack
+  // ---------------------------------------------------------------------------
+  async listPack(packName: string): Promise<StickerPackInfo> {
+    const set = await this.api.getStickerSet(packName);
+    return {
+      name: set.name,
+      title: set.title,
+      sticker_type: set.sticker_type || "regular",
+      contains_animated: set.contains_animated || false,
+      contains_video: set.contains_video || false,
+      stickers: set.stickers.map((s: any, i: number) => ({
+        file_id: s.file_id,
+        file_unique_id: s.file_unique_id,
+        index: i + 1,
+        is_animated: s.is_animated || false,
+        is_video: s.is_video || false,
+        emoji: s.emoji,
+      })),
+      total: set.stickers.length,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // sticker_send
+  // ---------------------------------------------------------------------------
+  async send(params: {
+    chatId: string;
+    packName?: string;
+    index?: number;
+    fileId?: string;
+    random?: boolean;
+    batch?: any[];
+    delayMs?: number;
+  }): Promise<StickerSendResult | StickerSendResult[]> {
+    if (params.batch?.length) {
+      return this.sendBatch(params.chatId, params.batch, params.delayMs);
+    }
+    return this.sendSingle(params);
+  }
+
+  private async sendSingle(params: any): Promise<StickerSendResult> {
+    try {
+      let fileId: string;
+      
+      if (params.fileId) {
+        fileId = params.fileId;
+      } else if (params.packName) {
+        const set = await this.api.getStickerSet(params.packName);
+        if (params.random) {
+          const idx = Math.floor(Math.random() * set.stickers.length);
+          fileId = set.stickers[idx].file_id;
+        } else if (params.index) {
+          if (params.index < 1 || params.index > set.stickers.length) {
+            return { success: false, error: `Index out of range (1-${set.stickers.length})` };
+          }
+          fileId = set.stickers[params.index - 1].file_id;
+        } else {
+          return { success: false, error: "Missing index or random flag" };
+        }
+      } else {
+        return { success: false, error: "Missing packName or fileId" };
+      }
+
+      const result = await this.api.sendSticker(params.chatId, fileId);
+      return { success: true, messageId: result.message_id };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
+  }
+
+  private async sendBatch(chatId: string, batch: any[], delayMs?: number): Promise<StickerSendResult[]> {
+    const results: StickerSendResult[] = [];
+    for (const item of batch) {
+      results.push(await this.sendSingle({ chatId, ...item }));
+      if (results.length < batch.length) {
+        await this.delay(delayMs || this.defaultDelay);
+      }
+    }
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // sticker_download_pack
+  // ---------------------------------------------------------------------------
+  async download(params: {
+    packName: string;
+    outputDir?: string;
+    limit?: number;
+    createIndex?: boolean;
+  }): Promise<StickerDownloadResult> {
+    try {
+      const set = await this.api.getStickerSet(params.packName);
+      const outputDir = params.outputDir || `./downloads/${params.packName}`;
+      await mkdir(outputDir, { recursive: true });
+
+      const files: string[] = [];
+      let downloaded = 0, failed = 0;
+      const toDownload = params.limit ? set.stickers.slice(0, params.limit) : set.stickers;
+
+      for (let i = 0; i < toDownload.length; i++) {
+        const sticker = toDownload[i];
+        const ext = sticker.is_video ? "webm" : sticker.is_animated ? "tgs" : "webp";
+        const filename = `${params.packName}_${String(i + 1).padStart(3, "0")}.${ext}`;
+        
+        try {
+          const fileInfo = await this.api.getFile(sticker.file_id);
+          const data = await this.api.downloadFile(fileInfo.file_path);
+          await writeFile(join(outputDir, filename), data);
+          files.push(filename);
+          downloaded++;
+        } catch {
+          failed++;
+        }
+        
+        if (i < toDownload.length - 1) await this.delay(this.defaultDelay);
+      }
+
+      if (params.createIndex !== false) {
+        const index = {
+          name: set.name, title: set.title,
+          total: set.stickers.length, downloaded, failed,
+          stickers: toDownload.map((s: any, i: number) => ({
+            index: i + 1, file_id: s.file_id,
+            is_animated: s.is_animated, is_video: s.is_video, emoji: s.emoji,
+          })),
+        };
+        await writeFile(join(outputDir, "index.json"), JSON.stringify(index, null, 2));
+      }
+
+      return { success: failed === 0, downloaded, failed, outputPath: outputDir, files };
+    } catch (err) {
+      return { success: false, downloaded: 0, failed: 0, error: (err as Error).message };
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // sticker_search_packs
+  // ---------------------------------------------------------------------------
+  async search(query: string, limit: number = 10): Promise<Array<{ name: string; title: string; stickerCount: number }>> {
+    const popular = [
+      { name: "LINE_HATSUNE_MIKU_Pom_Ver", title: "HATSUNE MIKU Pom Ver.", keywords: ["miku", "hatsune", "vocaloid"], count: 40 },
+      { name: "Anya_Forger_S2_Part_2_by_Fix_x_Fox", title: "Anya Forger p2", keywords: ["anya", "spy", "family"], count: 49 },
+      { name: "KawaiiChino", title: "Kafuu Chino", keywords: ["chino", "gochiusa", "rabbit"], count: 106 },
+      { name: "Rieeeee_by_fStikBot", title: "李依依Bpl", keywords: ["meme", "chinese"], count: 49 },
+      { name: "Pusheen", title: "Pusheen", keywords: ["cat", "cute"], count: 40 },
+      { name: "PepeTheFrog", title: "Pepe The Frog", keywords: ["pepe", "frog", "meme"], count: 50 },
+      { name: "Doge", title: "Doge", keywords: ["doge", "dog", "meme"], count: 30 },
+    ];
+
+    const q = query.toLowerCase();
+    return popular
+      .filter(p => p.keywords.some(k => k.includes(q)) || p.title.toLowerCase().includes(q) || p.name.toLowerCase().includes(q))
+      .slice(0, limit)
+      .map(p => ({ name: p.name, title: p.title, stickerCount: p.count }));
+  }
+
+  private delay(ms: number) {
+    return new Promise(r => setTimeout(r, ms));
+  }
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+export function createStickerTools(botToken: string): StickerTools {
+  return new StickerTools(botToken);
+}


### PR DESCRIPTION
## Summary
- add unified sticker tools for Telegram sticker pack management
- support list/send/download/search workflow for stickers

## Notes
- branch: feat/sticker-tools
- ready for review and merge