### PR TITLE
feat(gateway): add concise-mode builtin for send_message-only output

### DIFF
--- a/pi-gateway/src/gateway/message-pipeline.ts
+++ b/pi-gateway/src/gateway/message-pipeline.ts
@@ -486,10 +486,10 @@ export async function processMessage(
   ctx.metrics?.recordLatency(durationMs);
 
   try {
-    // Group chat silent mode: if agent responds with [NO_REPLY], skip delivery.
+    // Silent mode: if agent responds with [NO_REPLY], skip delivery.
     const SILENT_TOKEN = "[NO_REPLY]";
-    if (source.chatType !== "dm" && outbound.text.includes(SILENT_TOKEN)) {
-      ctx.log.info(`[processMessage] SILENT: agent declined to reply in group ${sessionKey}`);
+    if (outbound.text.includes(SILENT_TOKEN)) {
+      ctx.log.info(`[processMessage] SILENT: agent declined to reply ${sessionKey}`);
       ctx.transcripts.logMeta(sessionKey, "silent_no_reply", { durationMs });
     } else {
       ctx.log.info(`[processMessage] Calling respond for ${sessionKey}, text=${outbound.text.length} chars`);

--- a/pi-gateway/src/plugins/builtin/concise-mode/index.test.ts
+++ b/pi-gateway/src/plugins/builtin/concise-mode/index.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import registerConciseMode from "./index.ts";
+import type { GatewayPluginApi, HookHandler, PluginHookName } from "../../types.ts";
+
+function createApi(pluginConfig?: Record<string, unknown>) {
+  const hooks = new Map<PluginHookName, HookHandler[]>();
+
+  const api: GatewayPluginApi = {
+    id: "concise-mode",
+    name: "concise-mode",
+    source: "gateway",
+    config: {} as any,
+    pluginConfig,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    registerChannel() {},
+    registerTool() {},
+    registerHook(events, handler) {
+      for (const event of events) {
+        const list = hooks.get(event) ?? [];
+        list.push(handler as HookHandler);
+        hooks.set(event, list);
+      }
+    },
+    registerHttpRoute() {},
+    registerGatewayMethod() {},
+    registerCommand() {},
+    registerService() {},
+    registerCli() {},
+    on(hook, handler) {
+      const list = hooks.get(hook) ?? [];
+      list.push(handler as HookHandler);
+      hooks.set(hook, list);
+    },
+    async dispatch() { return {}; },
+    async sendToChannel() {},
+    getSessionState() {
+      return {
+        sessionKey: "agent:main:telegram:dm:u1",
+        role: null,
+        isStreaming: false,
+        lastActivity: Date.now(),
+        messageCount: 1,
+        rpcProcessId: null,
+        lastChannel: "telegram",
+        lastChatId: "chat-1",
+      };
+    },
+    async resetSession() {},
+    async setThinkingLevel() {},
+    async setModel() {},
+    async getAvailableModels() { return []; },
+    async getSessionMessageMode() { return "steer" as const; },
+    async setSessionMessageMode() {},
+    async compactSession() {},
+    async abortSession() {},
+    async forwardCommand() {},
+    async getPiCommands() { return []; },
+    async getSessionStats() { return {}; },
+    async getRpcState() { return {}; },
+    listSessions() { return []; },
+    releaseSession() {},
+  };
+
+  return { api, hooks };
+}
+
+async function runHook<T extends PluginHookName>(
+  hooks: Map<PluginHookName, HookHandler[]>,
+  name: T,
+  payload: Parameters<HookHandler<T>>[0],
+) {
+  for (const handler of hooks.get(name) ?? []) {
+    await handler(payload as any);
+  }
+}
+
+describe("builtin concise-mode plugin", () => {
+  test("injects concise instruction + suppresses final outbound after send_message", async () => {
+    const { api, hooks } = createApi({ enabled: true, channels: ["telegram"] });
+    registerConciseMode(api);
+
+    const inbound: any = {
+      message: {
+        source: { channel: "telegram" },
+        sessionKey: "agent:main:telegram:dm:u1",
+        text: "hello",
+      },
+    };
+
+    await runHook(hooks, "message_received", inbound);
+    expect(inbound.message.text).toContain("[Concise Output Mode]");
+
+    await runHook(hooks, "after_tool_call", {
+      sessionKey: "agent:main:telegram:dm:u1",
+      toolName: "send_message",
+      result: {},
+      isError: false,
+    });
+
+    const outbound: any = { message: { channel: "telegram", target: "chat-1", text: "normal reply" } };
+    await runHook(hooks, "message_sending", outbound);
+
+    expect(outbound.message.text).toBe("[NO_REPLY]");
+  });
+
+  test("does not activate for channels outside allowlist", async () => {
+    const { api, hooks } = createApi({ enabled: true, channels: ["telegram"] });
+    registerConciseMode(api);
+
+    const inbound: any = {
+      message: {
+        source: { channel: "discord" },
+        sessionKey: "agent:main:discord:dm:u1",
+        text: "hello",
+      },
+    };
+
+    await runHook(hooks, "message_received", inbound);
+    expect(inbound.message.text).toBe("hello");
+  });
+});

--- a/pi-gateway/src/plugins/builtin/concise-mode/index.ts
+++ b/pi-gateway/src/plugins/builtin/concise-mode/index.ts
@@ -1,0 +1,73 @@
+import type { GatewayPluginApi } from "../../types.ts";
+
+interface ConciseModeConfig {
+  enabled?: boolean;
+  channels?: string[];
+}
+
+const DEFAULT_CHANNELS = ["telegram"];
+const SILENT_TOKEN = "[NO_REPLY]";
+const PROMPT_SUFFIX = `
+
+[Concise Output Mode]
+- Communicate to user only via send_message tool.
+- Keep messages short and actionable.
+- If no user-facing message is needed, output exactly [NO_REPLY].`;
+
+function toConfig(raw: Record<string, unknown> | undefined): Required<ConciseModeConfig> {
+  const enabled = typeof raw?.enabled === "boolean" ? raw.enabled : false;
+  const channelsRaw = Array.isArray(raw?.channels) ? raw.channels : DEFAULT_CHANNELS;
+  const channels = channelsRaw.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+  return {
+    enabled,
+    channels: channels.length > 0 ? channels : [...DEFAULT_CHANNELS],
+  };
+}
+
+function makeRouteKey(channel: string, target: string): string {
+  return `${channel}::${target}`;
+}
+
+export default function register(api: GatewayPluginApi) {
+  const cfg = toConfig(api.pluginConfig);
+  if (!cfg.enabled) {
+    api.logger.info("concise-mode disabled");
+    return;
+  }
+
+  const enabledChannels = new Set(cfg.channels);
+  const channelEnabledSessions = new Set<string>();
+  const suppressRoutes = new Set<string>();
+
+  api.on("message_received", ({ message }) => {
+    if (!enabledChannels.has(message.source.channel)) {
+      channelEnabledSessions.delete(message.sessionKey);
+      return;
+    }
+    channelEnabledSessions.add(message.sessionKey);
+    message.text = `${message.text}${PROMPT_SUFFIX}`;
+  });
+
+  api.on("after_tool_call", ({ sessionKey, toolName, isError }) => {
+    if (!channelEnabledSessions.has(sessionKey)) return;
+    if (isError || toolName !== "send_message") return;
+
+    const session = api.getSessionState(sessionKey);
+    const channel = session?.lastChannel;
+    const target = session?.lastChatId;
+    if (!channel || !target || !enabledChannels.has(channel)) return;
+
+    suppressRoutes.add(makeRouteKey(channel, target));
+  });
+
+  api.on("message_sending", ({ message }) => {
+    if (!enabledChannels.has(message.channel)) return;
+    const key = makeRouteKey(message.channel, message.target);
+    if (!suppressRoutes.has(key)) return;
+
+    message.text = SILENT_TOKEN;
+    suppressRoutes.delete(key);
+  });
+
+  api.logger.info(`concise-mode enabled for channels: ${cfg.channels.join(", ")}`);
+}

--- a/pi-gateway/src/plugins/loader.ts
+++ b/pi-gateway/src/plugins/loader.ts
@@ -129,7 +129,7 @@ export class PluginLoader {
     const builtinDir = join(import.meta.dir, "builtin");
     if (!existsSync(builtinDir)) return;
 
-    const builtins = ["telegram", "discord", "webchat", "feishu", "cron", "heartbeat"];
+    const builtins = ["telegram", "discord", "webchat", "feishu", "cron", "heartbeat", "concise-mode"];
     for (const name of builtins) {
       // Support both single-file (name.ts) and modular (name/index.ts) layouts
       let path = join(builtinDir, `${name}.ts`);
@@ -143,7 +143,7 @@ export class PluginLoader {
 
       // BG-004: Skip unconfigured channels to avoid cold-start SDK import cost.
       // Non-channel builtins (cron, heartbeat) use their own enabled checks.
-      const isServicePlugin = name === "cron" || name === "heartbeat";
+      const isServicePlugin = name === "cron" || name === "heartbeat" || name === "concise-mode";
       if (!isServicePlugin && name !== "webchat") {
         const channelConfig = (this.config.channels as Record<string, any>)?.[name];
         if (!channelConfig || channelConfig.enabled === false) {


### PR DESCRIPTION
## Summary
- add builtin concise-mode plugin
- inject concise-mode prompt on message_received
- suppress final outbound text to [NO_REPLY] after successful send_message
- enable [NO_REPLY] silent behavior in DM and group
- add focused tests for concise-mode behavior

## Test
- bun test src/plugins/builtin/concise-mode/index.test.ts
