### PR TITLE
fix(telegram): 恢复正在输入状态触发

### DIFF
--- a/pi-gateway/src/plugins/builtin/telegram/streaming.ts
+++ b/pi-gateway/src/plugins/builtin/telegram/streaming.ts
@@ -515,7 +515,11 @@ export async function dispatchAgentTurn(params: {
       }
     },
     setTyping: async (typing) => {
-      if (!typing && typingInterval) {
+      if (typing) {
+        ensureTypingInterval();
+        return;
+      }
+      if (typingInterval) {
         clearInterval(typingInterval);
         typingInterval = null;
       }


### PR DESCRIPTION
## 变更
- 修复 Telegram streaming 中 `setTyping(true)` 未实际启动 typing 心跳的问题
- 现在 `setTyping(true)` 会立即调用 `ensureTypingInterval()`
- `setTyping(false)` 仍按原逻辑清理 interval

## 影响
- 在回复生成前与处理中，用户可稳定看到“正在输入”状态

## 验证
- 代码审查：确认 setTyping true/false 分支行为正确
- 本地 typecheck 受环境缺少 bun-types 影响未完成（TS2688）