### PR TITLE
feat: add onboarding wizard (pi-gw onboard)

### DIFF
--- a/pi-gateway/package.json
+++ b/pi-gateway/package.json
@@ -13,6 +13,7 @@
     "check": "bun run tsc --noEmit"
   },
   "dependencies": {
+    "@clack/prompts": "^0.10.0",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@larksuiteoapi/node-sdk": "^1.58.0",

--- a/pi-gateway/src/cli.ts
+++ b/pi-gateway/src/cli.ts
@@ -3,6 +3,7 @@
  * CLI entry point for pi-gateway.
  *
  * Commands (aligned with OpenClaw CLI surface):
+ *   pi-gw onboard [--install-daemon]        Interactive configuration wizard
  *   pi-gw gateway [--port N] [--verbose]    Start the gateway
  *   pi-gw doctor                            Health check
  *   pi-gw send --to <target> --message <m>  Send a message
@@ -15,6 +16,8 @@ import { listPendingRequests, approvePairingRequest } from "./security/pairing.t
 import { CronEngine } from "./core/cron.ts";
 import { installDaemon, uninstallDaemon } from "./core/daemon.ts";
 import { createPluginRegistry, PluginLoader } from "./plugins/loader.ts";
+import { runOnboardingWizard } from "./wizard/onboarding";
+import { createClackPrompter } from "./wizard/clack-prompter";
 import type {
   GatewayPluginApi,
   PluginManifest,
@@ -552,11 +555,54 @@ function formatBytes(bytes: number): string {
   return `${val.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
 
+async function runOnboard(): Promise<void> {
+  const prompter = createClackPrompter();
+
+  try {
+    const result = await runOnboardingWizard(
+      {
+        nonInteractive: getFlag("non-interactive"),
+        acceptRisk: getFlag("accept-risk"),
+        flow: getArg("flow") as "quickstart" | "advanced" | undefined,
+        workspace: getArg("workspace"),
+        port: getArg("port") ? parseInt(getArg("port")!, 10) : undefined,
+        bind: getArg("bind") as "loopback" | "lan" | "auto" | "custom" | undefined,
+        customHost: getArg("custom-host"),
+        auth: getArg("auth") as "token" | "password" | "off" | undefined,
+        token: getArg("token"),
+        password: getArg("password"),
+        telegramToken: getArg("telegram-token"),
+        piCliPath: getArg("pi-cli"),
+        poolMin: getArg("pool-min") ? parseInt(getArg("pool-min")!, 10) : undefined,
+        poolMax: getArg("pool-max") ? parseInt(getArg("pool-max")!, 10) : undefined,
+        installDaemon: getFlag("install-daemon"),
+        configPath: getArg("config"),
+      },
+      prompter,
+    );
+
+    console.log(`\n✅ ${result.message}`);
+
+    if (!getFlag("install-daemon")) {
+      console.log("\nNext steps:");
+      console.log(`  pi-gw gateway              # Start the gateway`);
+      console.log(`  pi-gw install-daemon       # Install as system service`);
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "WizardCancelledError") {
+      console.log("\n❌ Onboarding cancelled.");
+      process.exit(0);
+    }
+    throw err;
+  }
+}
+
 function showHelp(): void {
   console.log(`
 pi-gateway — Local AI Gateway for pi agent
 
 Usage:
+  pi-gw onboard [--install-daemon] [...]                  Interactive configuration wizard
   pi-gw gateway [--port N] [--verbose] [--no-gui] [--config path]   Start the gateway
   pi-gw doctor [--config path]                            Health check
   pi-gw send --to <target> --message <text>               Send a message (telegram:<chatId> or telegram:<accountId>:<chatId>[:topic:<tid>])
@@ -568,11 +614,20 @@ Usage:
   pi-gw cron remove <id>                                  Remove a cron job
   pi-gw media stats [--channel <ch>]                      Show media storage statistics
   pi-gw media clean [--days N] [--channel <ch>] [--dry-run]  Clean old media files
-  pi-gw media sticker-cache [stats|prune|clear]           Manage sticker cache
   pi-gw install-daemon [--port N]                         Install as system daemon
   pi-gw uninstall-daemon                                  Remove system daemon
   pi-gw help                                              Show this help
   pi-gw <plugin-command> [...]                            Run plugin-registered CLI command
+
+Onboarding options:
+  --flow quickstart|advanced      Choose wizard mode
+  --workspace <path>              Set workspace directory
+  --port <n>                      Gateway port
+  --bind loopback|lan|auto|custom Bind address mode
+  --auth token|password|off       Authentication mode
+  --telegram-token <token>        Telegram bot token
+  --install-daemon                Install as system service after config
+  --non-interactive               Non-interactive mode (use with other flags)
 
 Environment:
   PI_GATEWAY_CONFIG   Path to config file (default: ~/.pi/gateway/pi-gateway.jsonc)
@@ -584,6 +639,9 @@ Environment:
 // ============================================================================
 
 switch (command) {
+  case "onboard":
+    await runOnboard();
+    break;
   case "gateway":
   case "start":
     await runGateway();

--- a/pi-gateway/src/wizard/clack-prompter.ts
+++ b/pi-gateway/src/wizard/clack-prompter.ts
@@ -1,0 +1,112 @@
+/**
+ * Clack-based WizardPrompter implementation.
+ * Provides beautiful CLI prompts using @clack/prompts.
+ */
+
+import {
+  intro,
+  outro,
+  note,
+  select,
+  multiselect,
+  text,
+  confirm,
+  spinner,
+  isCancel,
+} from "@clack/prompts";
+import type {
+  WizardPrompter,
+  WizardSelectParams,
+  WizardMultiSelectParams,
+  WizardTextParams,
+  WizardConfirmParams,
+  WizardProgress,
+} from "./prompts";
+import { WizardCancelledError } from "./prompts";
+
+export function createClackPrompter(): WizardPrompter {
+  return {
+    async intro(title: string): Promise<void> {
+      intro(title);
+    },
+
+    async outro(message: string): Promise<void> {
+      outro(message);
+    },
+
+    async note(message: string, title?: string): Promise<void> {
+      note(message, title);
+    },
+
+    async select<T>(params: WizardSelectParams<T>): Promise<T> {
+      const result = await select({
+        message: params.message,
+        options: params.options as unknown as { value: T; label: string; hint?: string }[],
+        initialValue: params.initialValue,
+      });
+
+      if (isCancel(result)) {
+        throw new WizardCancelledError();
+      }
+
+      return result as T;
+    },
+
+    async multiselect<T>(params: WizardMultiSelectParams<T>): Promise<T[]> {
+      const result = await multiselect({
+        message: params.message,
+        options: params.options as unknown as { value: T; label: string; hint?: string }[],
+        initialValues: params.initialValues,
+        required: false,
+      });
+
+      if (isCancel(result)) {
+        throw new WizardCancelledError();
+      }
+
+      return result as T[];
+    },
+
+    async text(params: WizardTextParams): Promise<string> {
+      const result = await text({
+        message: params.message,
+        defaultValue: params.initialValue,
+        placeholder: params.placeholder,
+        validate: params.validate,
+      });
+
+      if (isCancel(result)) {
+        throw new WizardCancelledError();
+      }
+
+      return result;
+    },
+
+    async confirm(params: WizardConfirmParams): Promise<boolean> {
+      const result = await confirm({
+        message: params.message,
+        initialValue: params.initialValue,
+      });
+
+      if (isCancel(result)) {
+        throw new WizardCancelledError();
+      }
+
+      return result;
+    },
+
+    progress(label: string): WizardProgress {
+      const s = spinner();
+      s.start(label);
+
+      return {
+        update: (message: string) => {
+          s.message(message);
+        },
+        stop: (message?: string) => {
+          s.stop(message ?? label);
+        },
+      };
+    },
+  };
+}

--- a/pi-gateway/src/wizard/onboarding-types.ts
+++ b/pi-gateway/src/wizard/onboarding-types.ts
@@ -1,0 +1,89 @@
+/**
+ * Onboarding wizard types — aligned with OpenClaw onboarding patterns.
+ */
+
+import type { Config } from "../core/config.ts";
+
+export type WizardFlow = "quickstart" | "advanced";
+
+export type OnboardMode = "local" | "remote";
+
+export type GatewayBind = "loopback" | "lan" | "auto" | "custom";
+
+export type AuthMode = "token" | "password" | "off";
+
+export interface OnboardOptions {
+  /** Non-interactive mode — all values from CLI args */
+  nonInteractive?: boolean;
+
+  /** Accept security risk without prompt */
+  acceptRisk?: boolean;
+
+  /** Wizard flow mode */
+  flow?: WizardFlow;
+
+  /** Local or remote gateway */
+  mode?: OnboardMode;
+
+  /** Workspace directory path */
+  workspace?: string;
+
+  /** Gateway port */
+  port?: number;
+
+  /** Gateway bind mode */
+  bind?: GatewayBind;
+
+  /** Custom bind host (when bind=custom) */
+  customHost?: string;
+
+  /** Authentication mode */
+  auth?: AuthMode;
+
+  /** Auth token (when auth=token) */
+  token?: string;
+
+  /** Auth password (when auth=password) */
+  password?: string;
+
+  /** Telegram bot token */
+  telegramToken?: string;
+
+  /** Pi CLI path */
+  piCliPath?: string;
+
+  /** Default model */
+  model?: string;
+
+  /** Pool min size */
+  poolMin?: number;
+
+  /** Pool max size */
+  poolMax?: number;
+
+  /** Install daemon after configuration */
+  installDaemon?: boolean;
+
+  /** Config file path to write */
+  configPath?: string;
+
+  /** Skip interactive prompts */
+  yes?: boolean;
+}
+
+export interface QuickstartDefaults {
+  hasExisting: boolean;
+  port: number;
+  bind: GatewayBind;
+  customHost?: string;
+  authMode: AuthMode;
+  token?: string;
+  password?: string;
+}
+
+export interface OnboardingResult {
+  success: boolean;
+  config: Config;
+  configPath: string;
+  message: string;
+}

--- a/pi-gateway/src/wizard/onboarding.ts
+++ b/pi-gateway/src/wizard/onboarding.ts
@@ -1,0 +1,496 @@
+/**
+ * Onboarding wizard implementation — aligned with OpenClaw onboarding patterns.
+ * Interactive configuration generator for pi-gateway.
+ */
+
+import { resolve, join } from "node:path";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import type {
+  Config,
+  TelegramChannelConfig,
+  GatewayConfig,
+} from "../core/config";
+import { loadConfig, saveConfig, resolveConfigPath, DEFAULT_CONFIG } from "../core/config";
+import type { WizardPrompter } from "./prompts";
+import { WizardCancelledError } from "./prompts";
+import type {
+  OnboardOptions,
+  OnboardingResult,
+  WizardFlow,
+  GatewayBind,
+  AuthMode,
+} from "./onboarding-types";
+import { createClackPrompter } from "./clack-prompter";
+import { installDaemon } from "../core/daemon";
+
+const DEFAULT_PORT = 52134;
+const DEFAULT_POOL_MIN = 1;
+const DEFAULT_POOL_MAX = 4;
+
+/**
+ * Generate a secure random token for gateway auth.
+ */
+function generateToken(): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < 32; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+/**
+ * Resolve user path (handles ~ expansion).
+ */
+function resolveUserPath(input: string): string {
+  if (input.startsWith("~/")) {
+    return join(process.env.HOME ?? "/root", input.slice(2));
+  }
+  return resolve(input);
+}
+
+/**
+ * Check if a port is available using TCP socket.
+ */
+async function isPortAvailable(port: number): Promise<boolean> {
+  try {
+    const listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data() {},
+        open() {},
+        close() {},
+        drain() {},
+      },
+    });
+    await listener.stop();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find next available port starting from given port.
+ */
+async function findAvailablePort(startPort: number): Promise<number> {
+  for (let port = startPort; port < startPort + 100; port++) {
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+  return startPort;
+}
+
+/**
+ * Validate Telegram bot token format.
+ */
+function isValidTelegramToken(token: string): boolean {
+  return /^\d+:[A-Za-z0-9_-]+$/.test(token);
+}
+
+/**
+ * Read existing config or return empty object.
+ */
+async function readExistingConfig(
+  configPath?: string,
+): Promise<{ exists: boolean; config: Partial<Config>; valid: boolean }> {
+  try {
+    const path = configPath ?? resolveConfigPath();
+    if (!existsSync(path)) {
+      return { exists: false, config: {}, valid: true };
+    }
+    const config = loadConfig(path);
+    return { exists: true, config, valid: true };
+  } catch {
+    return { exists: true, config: {}, valid: false };
+  }
+}
+
+/**
+ * Run the onboarding wizard.
+ */
+export async function runOnboardingWizard(
+  opts: OnboardOptions = {},
+  prompter: WizardPrompter = createClackPrompter(),
+): Promise<OnboardingResult> {
+  const startTime = Date.now();
+
+  // Intro
+  await prompter.intro("🚀 pi-gateway onboarding");
+
+  // Security warning
+  if (!opts.acceptRisk && !opts.nonInteractive) {
+    await prompter.note(
+      [
+        "Security notice:",
+        "",
+        "• This gateway can execute commands and access files via tools.",
+        "• Default DM policy is 'pairing' — unknown users must be approved.",
+        "• Keep your bot tokens secure and rotate them regularly.",
+        "• Use 'loopback' bind for local-only access when possible.",
+        "",
+        "Review security settings in docs/guides/configuration.md",
+      ].join("\n"),
+      "⚠️  Security",
+    );
+
+    const accepted = await prompter.confirm({
+      message: "I understand the security implications. Continue?",
+      initialValue: false,
+    });
+
+    if (!accepted) {
+      throw new WizardCancelledError("security warning not accepted");
+    }
+  }
+
+  // Read existing config
+  const { exists: configExists, config: existingConfig, valid: configValid } =
+    await readExistingConfig(opts.configPath);
+
+  if (configExists && !configValid) {
+    await prompter.note(
+      "Existing config is invalid. Please fix it manually or reset.",
+      "Config Error",
+    );
+    throw new WizardCancelledError("invalid existing config");
+  }
+
+  // Determine flow mode
+  let flow: WizardFlow = opts.flow ?? "quickstart";
+  if (!opts.nonInteractive && !opts.flow) {
+    const hasExisting = configExists && Object.keys(existingConfig).length > 0;
+
+    if (hasExisting) {
+      await prompter.note(
+        `Existing config detected at: ${resolveConfigPath()}`,
+        "Config Found",
+      );
+
+      const action = await prompter.select<"keep" | "modify" | "reset">({
+        message: "How would you like to proceed?",
+        options: [
+          { value: "keep", label: "Keep existing", hint: "Use current config as base" },
+          { value: "modify", label: "Modify", hint: "Update specific values" },
+          { value: "reset", label: "Reset", hint: "Start fresh" },
+        ],
+        initialValue: "keep",
+      });
+
+      if (action === "reset") {
+        flow = "advanced";
+      } else if (action === "modify") {
+        flow = "advanced";
+      }
+      // keep uses quickstart with existing values
+    }
+
+    if (!opts.flow) {
+      flow = await prompter.select<WizardFlow>({
+        message: "Choose onboarding mode",
+        options: [
+          {
+            value: "quickstart",
+            label: "QuickStart",
+            hint: "Minimal setup, smart defaults",
+          },
+          {
+            value: "advanced",
+            label: "Advanced",
+            hint: "Full control over all options",
+          },
+        ],
+        initialValue: flow,
+      });
+    }
+  }
+
+  // Build config starting from defaults
+  let config: Config = { ...DEFAULT_CONFIG };
+
+  // Merge with existing if keeping
+  if (existingConfig) {
+    config = mergeConfigs(config, existingConfig);
+  }
+
+  // Workspace directory (stored in roles.workspaceDirs or agents.defaults.workspace)
+  const workspaceDir = opts.workspace
+    ? resolveUserPath(opts.workspace)
+    : flow === "quickstart"
+    ? resolveUserPath("~/.pi/gateway/workspace")
+    : resolveUserPath(
+        await prompter.text({
+          message: "Workspace directory",
+          initialValue: "~/.pi/gateway/workspace",
+          validate: (v) => {
+            if (!v.trim()) return "Workspace path is required";
+            return undefined;
+          },
+        }),
+      );
+
+  // Ensure workspace exists
+  await mkdir(workspaceDir, { recursive: true });
+
+  // Gateway configuration
+  const port = opts.port ??
+    (flow === "quickstart"
+      ? (existingConfig.gateway?.port ?? DEFAULT_PORT)
+      : await promptForPort(prompter, existingConfig.gateway?.port));
+
+  const bind: GatewayBind = opts.bind ??
+    (flow === "quickstart"
+      ? ((existingConfig.gateway?.bind as GatewayBind) ?? "loopback")
+      : await prompter.select<GatewayBind>({
+        message: "Gateway bind address",
+        options: [
+          { value: "loopback", label: "Loopback (127.0.0.1)", hint: "Local access only" },
+          { value: "lan", label: "LAN", hint: "Accessible on local network" },
+          { value: "auto", label: "Auto", hint: "Bind to all interfaces" },
+        ],
+        initialValue: (existingConfig.gateway?.bind as GatewayBind) ?? "loopback",
+      }));
+
+  // Auth configuration
+  const authMode: AuthMode = opts.auth ??
+    (flow === "quickstart"
+      ? (existingConfig.gateway?.auth?.token ? "token" : "token")
+      : await prompter.select<AuthMode>({
+        message: "Authentication mode",
+        options: [
+          { value: "token", label: "Token", hint: "Random secure token (recommended)" },
+          { value: "password", label: "Password", hint: "Custom password" },
+          { value: "off", label: "Off", hint: "No authentication (not recommended)" },
+        ],
+        initialValue: existingConfig.gateway?.auth?.token
+          ? "token"
+          : existingConfig.gateway?.auth?.password
+          ? "password"
+          : "token",
+      }));
+
+  let token: string | undefined;
+  let password: string | undefined;
+
+  if (authMode === "token") {
+    token = opts.token ??
+      (flow === "quickstart" && existingConfig.gateway?.auth?.token
+        ? existingConfig.gateway.auth.token
+        : generateToken());
+  } else if (authMode === "password") {
+    password = opts.password ??
+      (await prompter.text({
+        message: "Set gateway password",
+        initialValue: existingConfig.gateway?.auth?.password,
+        validate: (v) => {
+          if (!v || v.length < 8) return "Password must be at least 8 characters";
+          return undefined;
+        },
+      }));
+  }
+
+  // Check port availability
+  if (!opts.nonInteractive) {
+    const isAvailable = await isPortAvailable(port);
+    if (!isAvailable) {
+      const newPort = await findAvailablePort(port + 1);
+      await prompter.note(
+        `Port ${port} is in use. Switching to ${newPort}.`,
+        "Port Adjusted",
+      );
+    }
+  }
+
+  // Telegram configuration
+  let telegramConfig: TelegramChannelConfig | undefined;
+  if (flow === "advanced" || opts.telegramToken) {
+    const enableTelegram = opts.telegramToken
+      ? true
+      : await prompter.confirm({
+        message: "Enable Telegram channel?",
+        initialValue: !!existingConfig.channels?.telegram?.enabled,
+      });
+
+    if (enableTelegram) {
+      const botToken = opts.telegramToken ??
+        (await prompter.text({
+          message: "Telegram bot token (from @BotFather)",
+          initialValue: existingConfig.channels?.telegram?.botToken,
+          validate: (v) => {
+            if (!v) return undefined; // Optional
+            if (!isValidTelegramToken(v)) return "Invalid token format (expected: numbers:alphanumeric)";
+            return undefined;
+          },
+        }));
+
+      if (botToken) {
+        telegramConfig = {
+          enabled: true,
+          botToken,
+          dmPolicy: existingConfig.channels?.telegram?.dmPolicy ?? "pairing",
+        };
+      }
+    }
+  }
+
+  // Agent configuration
+  const piCliPath = opts.piCliPath ??
+    (flow === "quickstart"
+      ? (existingConfig.agent?.piCliPath ?? "pi")
+      : await prompter.text({
+        message: "Pi CLI path",
+        initialValue: existingConfig.agent?.piCliPath ?? "pi",
+      }));
+
+  const poolMin = opts.poolMin ??
+    (existingConfig.agent?.pool?.min ?? DEFAULT_POOL_MIN);
+  const poolMax = opts.poolMax ??
+    (existingConfig.agent?.pool?.max ?? DEFAULT_POOL_MAX);
+
+  // Build final config
+  config = {
+    ...config,
+    gateway: {
+      ...config.gateway,
+      port,
+      bind: bind as "loopback" | "lan" | "auto",
+      auth: {
+        mode: authMode === "off" ? "off" : authMode,
+        ...(token && { token }),
+        ...(password && { password }),
+      },
+    },
+    agent: {
+      ...config.agent,
+      piCliPath,
+      pool: {
+        min: poolMin,
+        max: poolMax,
+        idleTimeoutMs: config.agent.pool?.idleTimeoutMs ?? 300000,
+      },
+    },
+    channels: {
+      ...config.channels,
+      ...(telegramConfig && { telegram: telegramConfig }),
+    },
+    roles: {
+      ...config.roles,
+      workspaceDirs: {
+        ...config.roles?.workspaceDirs,
+        default: workspaceDir,
+      },
+    },
+  };
+
+  // Preview config in advanced mode
+  if (flow === "advanced" && !opts.nonInteractive) {
+    await prompter.note(
+      JSON.stringify(
+        {
+          gateway: {
+            port: config.gateway.port,
+            bind: config.gateway.bind,
+            auth: config.gateway.auth.mode,
+          },
+          agent: {
+            piCliPath: config.agent.piCliPath,
+            pool: config.agent.pool,
+          },
+          channels: {
+            telegram: config.channels.telegram?.enabled ? "enabled" : "not configured",
+          },
+        },
+        null,
+        2,
+      ),
+      "Configuration Preview",
+    );
+
+    const confirmed = await prompter.confirm({
+      message: "Save this configuration?",
+      initialValue: true,
+    });
+
+    if (!confirmed) {
+      throw new WizardCancelledError("user cancelled after preview");
+    }
+  }
+
+  // Save config
+  const configPath = opts.configPath ?? resolveConfigPath();
+  saveConfig(config, configPath);
+
+  // Success message
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+  await prompter.outro(`Configuration saved to ${configPath} (${duration}s)`);
+
+  // Install daemon if requested
+  if (opts.installDaemon) {
+    const progress = prompter.progress("Installing system daemon...");
+    try {
+      installDaemon({ port, configPath });
+      progress.stop("Daemon installed successfully");
+    } catch (err: unknown) {
+      progress.stop("Daemon installation failed");
+      throw err;
+    }
+  }
+
+  return {
+    success: true,
+    config,
+    configPath,
+    message: `Configuration complete. Start with: pi-gw gateway${opts.installDaemon ? " (daemon auto-starts)" : ""}`,
+  };
+}
+
+/**
+ * Merge existing config with defaults.
+ */
+function mergeConfigs(defaults: Config, existing: Partial<Config>): Config {
+  return {
+    ...defaults,
+    ...existing,
+    gateway: { ...defaults.gateway, ...existing.gateway },
+    agent: {
+      ...defaults.agent,
+      ...existing.agent,
+      pool: { ...defaults.agent?.pool, ...existing.agent?.pool },
+    },
+    session: { ...defaults.session, ...existing.session },
+    channels: { ...defaults.channels, ...existing.channels },
+    plugins: { ...defaults.plugins, ...existing.plugins },
+    roles: { ...defaults.roles, ...existing.roles },
+    hooks: { ...defaults.hooks, ...existing.hooks },
+    cron: { ...defaults.cron, ...existing.cron },
+    logging: { ...defaults.logging, ...existing.logging },
+    queue: { ...defaults.queue, ...existing.queue },
+    delegation: { ...defaults.delegation, ...existing.delegation },
+  };
+}
+
+/**
+ * Prompt for port with validation.
+ */
+async function promptForPort(
+  prompter: WizardPrompter,
+  existingPort?: number,
+): Promise<number> {
+  const input = await prompter.text({
+    message: "Gateway port",
+    initialValue: String(existingPort ?? DEFAULT_PORT),
+    validate: (v) => {
+      const port = parseInt(v, 10);
+      if (isNaN(port) || port < 1 || port > 65535) {
+        return "Port must be between 1 and 65535";
+      }
+      return undefined;
+    },
+  });
+
+  return parseInt(input, 10);
+}

--- a/pi-gateway/src/wizard/prompts.ts
+++ b/pi-gateway/src/wizard/prompts.ts
@@ -1,0 +1,57 @@
+/**
+ * Wizard prompter interface — aligned with OpenClaw prompts.ts
+ * Abstracts UI library for testability and future UI changes.
+ */
+
+export type WizardSelectOption<T = string> = {
+  value: T;
+  label: string;
+  hint?: string;
+};
+
+export type WizardSelectParams<T = string> = {
+  message: string;
+  options: Array<WizardSelectOption<T>>;
+  initialValue?: T;
+};
+
+export type WizardMultiSelectParams<T = string> = {
+  message: string;
+  options: Array<WizardSelectOption<T>>;
+  initialValues?: T[];
+};
+
+export type WizardTextParams = {
+  message: string;
+  initialValue?: string;
+  placeholder?: string;
+  validate?: (value: string) => string | undefined;
+};
+
+export type WizardConfirmParams = {
+  message: string;
+  initialValue?: boolean;
+};
+
+export type WizardProgress = {
+  update: (message: string) => void;
+  stop: (message?: string) => void;
+};
+
+export type WizardPrompter = {
+  intro: (title: string) => Promise<void>;
+  outro: (message: string) => Promise<void>;
+  note: (message: string, title?: string) => Promise<void>;
+  select: <T>(params: WizardSelectParams<T>) => Promise<T>;
+  multiselect: <T>(params: WizardMultiSelectParams<T>) => Promise<T[]>;
+  text: (params: WizardTextParams) => Promise<string>;
+  confirm: (params: WizardConfirmParams) => Promise<boolean>;
+  progress: (label: string) => WizardProgress;
+};
+
+export class WizardCancelledError extends Error {
+  constructor(message = "wizard cancelled") {
+    super(message);
+    this.name = "WizardCancelledError";
+  }
+}


### PR DESCRIPTION
## Summary

Add interactive configuration wizard aligned with OpenClaw onboarding patterns.

## Changes

- **New command**: `pi-gw onboard` — Interactive configuration wizard
- **Interactive mode**: Beautiful CLI prompts via @clack/prompts
- **Non-interactive mode**: `--non-interactive` flag for automation
- **Options supported**:
  - `--flow quickstart|advanced`
  - `--port`, `--bind`, `--auth`
  - `--telegram-token`
  - `--install-daemon`

## New Files

- `src/wizard/prompts.ts` — Abstract wizard interface
- `src/wizard/clack-prompter.ts` — @clack/prompts implementation
- `src/wizard/onboarding-types.ts` — Type definitions
- `src/wizard/onboarding.ts` — Main wizard logic

## Dependencies

- Added `@clack/prompts` for beautiful CLI prompts

## Testing

```bash
# Interactive mode
pi-gw onboard

# Non-interactive mode
pi-gw onboard --non-interactive --accept-risk --port 55555
```

Closes onboarding gap with OpenClaw (`openclaw onboard`).