### PR TITLE
feat(role-persona): external readonly memory integration

### DIFF
--- a/extensions/role-persona/CHANGELOG.md
+++ b/extensions/role-persona/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-02-19
+
+### Added
+- **外部只读记忆增强** (`externalReadonly`): 可选接入只读记忆服务（如 pi-session-manager）
+  - `before_agent_start` 调用 `/v1/memory/unified`，按置信度注入跨会话 hints（evidence + next_actions）
+  - `agent_end` 调用 `/v1/experience/extract`，记录候选经验数量（仅日志）
+  - 失败自动降级，不影响原有 MEMORY.md 与向量记忆流程
+- **配置项**: `pi-role-persona.jsonc` 新增 `externalReadonly` 配置段
+  - `enabled` / `baseUrl` / `token` / `timeoutMs` / `topK` / `experienceLimit` / `minConfidence`
+  - 环境变量: `ROLE_EXTERNAL_READONLY`, `ROLE_EXTERNAL_BASE_URL`, `ROLE_EXTERNAL_TOKEN`, `ROLE_EXTERNAL_TIMEOUT_MS`, `ROLE_EXTERNAL_TOP_K`, `ROLE_EXTERNAL_EXP_LIMIT`, `ROLE_EXTERNAL_MIN_CONFIDENCE`
+
 ## 2026-02-16
 
 ### Added

--- a/extensions/role-persona/README.md
+++ b/extensions/role-persona/README.md
@@ -342,6 +342,11 @@ LLM 自动为每条记忆提取语义标签，存储在 `.log/memory-tags.json`�
 | advanced | `shutdownFlushTimeoutMs` | `15000` | 退出 flush 超时 |
 | advanced | `forceKeywords` | `结束\|总结\|退出...` | 强制触发关键词正则 |
 | logging | `enabled` | `true` | 文件日志开关（`ROLE_LOG`） |
+| externalReadonly | `enabled` | `false` | 外部只读记忆增强开关（`ROLE_EXTERNAL_READONLY`） |
+| externalReadonly | `baseUrl` | `http://127.0.0.1:52131` | 只读服务地址（`ROLE_EXTERNAL_BASE_URL`） |
+| externalReadonly | `topK` | `8` | unified 查询条数（`ROLE_EXTERNAL_TOP_K`） |
+| externalReadonly | `experienceLimit` | `8` | experience 提取条数（`ROLE_EXTERNAL_EXP_LIMIT`） |
+| externalReadonly | `minConfidence` | `0.35` | 注入阈值（`ROLE_EXTERNAL_MIN_CONFIDENCE`） |
 
 详细迁移说明见 [CONFIG-MIGRATION.md](./CONFIG-MIGRATION.md)。
 

--- a/extensions/role-persona/pi-role-persona.jsonc
+++ b/extensions/role-persona/pi-role-persona.jsonc
@@ -161,5 +161,36 @@
 
     // 向量数据库存储路径（相对于 rolePath）
     "dbPath": ".vector-db"
+  },
+
+  // ==================== 外部只读记忆增强（可选） ====================
+  "externalReadonly": {
+    // 总开关：是否接入外部只读记忆服务
+    // 环境变量覆盖：ROLE_EXTERNAL_READONLY
+    "enabled": false,
+
+    // 服务地址（不带 /api 前缀）
+    // 环境变量覆盖：ROLE_EXTERNAL_BASE_URL
+    "baseUrl": "http://127.0.0.1:52131",
+
+    // 可选鉴权 token
+    // 环境变量覆盖：ROLE_EXTERNAL_TOKEN
+    "token": null,
+
+    // 超时毫秒
+    // 环境变量覆盖：ROLE_EXTERNAL_TIMEOUT_MS
+    "timeoutMs": 1200,
+
+    // unified 查询 top_k
+    // 环境变量覆盖：ROLE_EXTERNAL_TOP_K
+    "topK": 8,
+
+    // experience 抽取 limit
+    // 环境变量覆盖：ROLE_EXTERNAL_EXP_LIMIT
+    "experienceLimit": 8,
+
+    // unified 注入最小置信度
+    // 环境变量覆盖：ROLE_EXTERNAL_MIN_CONFIDENCE
+    "minConfidence": 0.35
   }
 }


### PR DESCRIPTION
## Summary
Upgrade role-persona with optional external **readonly memory** integration (DB/API-backed hints), while keeping existing MEMORY.md flow unchanged.

### What changed
- `config.ts`
  - Added `externalReadonly` config block + env overrides:
    - `ROLE_EXTERNAL_READONLY`
    - `ROLE_EXTERNAL_BASE_URL`
    - `ROLE_EXTERNAL_TOKEN`
    - `ROLE_EXTERNAL_TIMEOUT_MS`
    - `ROLE_EXTERNAL_TOP_K`
    - `ROLE_EXTERNAL_EXP_LIMIT`
    - `ROLE_EXTERNAL_MIN_CONFIDENCE`
- `index.ts`
  - `before_agent_start`: best-effort call to `/v1/memory/unified`, inject hints when confidence >= threshold.
  - `agent_end`: best-effort call to `/v1/experience/extract`, log count only.
  - Failure path degrades silently (does not block normal role workflow).
- `pi-role-persona.jsonc`
  - Added default `externalReadonly` config section.
- `README.md`, `CHANGELOG.md`
  - Documented new config and behavior.

## Safety / Behavior
- Read-only calls only; no write path added.
- Existing MEMORY.md + vector memory behavior remains the primary path.
- External integration is opt-in (`enabled: false` by default).
