### PR TITLE
feat(pi-gateway): role-workspace-channel mapping for multi-agent routing (#16)

### DIFF
--- a/pi-gateway/admin-console/src/pages/settings-page.tsx
+++ b/pi-gateway/admin-console/src/pages/settings-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { Activity, Trash2, BarChart3 } from 'lucide-react';
+import { Activity, Trash2, BarChart3, Route, FolderKanban, Users } from 'lucide-react';
 import { PermissionGate } from '../components/permission-gate';
 import { usePageDataSource, useDataMutation } from '../hooks/use-data-source';
 import { fetchGatewayConfig, reloadGatewayConfig, restartGateway } from '../lib/api';
@@ -75,6 +75,100 @@ function ObservabilityPanel() {
   );
 }
 
+function RouteMappingPanel({ config }: { config: Record<string, unknown> }) {
+  const agents = (((config.agents as any)?.list ?? []) as Array<Record<string, unknown>>).map((a) => ({
+    id: String(a.id ?? ''),
+    role: String(a.role ?? ''),
+    workspace: String(a.workspace ?? ''),
+  }));
+
+  const bindings = (((config.agents as any)?.bindings ?? []) as Array<Record<string, unknown>>).map((b) => {
+    const match = (b.match ?? {}) as Record<string, any>;
+    const peer = match.peer ? `${match.peer.kind ?? 'peer'}:${match.peer.id ?? '*'}` : '-';
+    const parentPeer = match.parentPeer ? `${match.parentPeer.kind ?? 'parent'}:${match.parentPeer.id ?? '*'}` : '-';
+    const roles = Array.isArray(match.roles) ? match.roles.join(',') : '-';
+    return {
+      agentId: String(b.agentId ?? ''),
+      channel: String(match.channel ?? '*'),
+      accountId: String(match.accountId ?? '*'),
+      guildId: String(match.guildId ?? '-'),
+      roles,
+      peer,
+      parentPeer,
+    };
+  });
+
+  const workspaceEntries = Object.entries(((config.roles as any)?.workspaceDirs ?? {}) as Record<string, string>);
+
+  return (
+    <div className="rounded-xl border border-slate-800 bg-card p-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <Route className="h-4 w-4 text-violet-400" />
+        <h2 className="text-sm font-semibold text-slate-200">Role / Workspace / Channel / Agent Mapping</h2>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-3">
+        <section className="rounded-lg border border-slate-800 bg-slate-900/30 p-3 lg:col-span-1">
+          <div className="mb-2 flex items-center gap-2 text-xs text-slate-300">
+            <Users className="h-3.5 w-3.5 text-sky-400" /> Agents
+          </div>
+          <div className="space-y-2 text-xs">
+            {agents.length === 0 ? (
+              <p className="text-slate-500">No agents configured (single-agent mode).</p>
+            ) : (
+              agents.map((a) => (
+                <div key={a.id} className="rounded border border-slate-700 bg-slate-900 p-2">
+                  <p className="font-mono text-slate-100">{a.id}</p>
+                  <p className="text-slate-400">role: {a.role || '-'}</p>
+                  <p className="text-slate-400 break-all">workspace: {a.workspace || '-'}</p>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-800 bg-slate-900/30 p-3 lg:col-span-1">
+          <div className="mb-2 flex items-center gap-2 text-xs text-slate-300">
+            <FolderKanban className="h-3.5 w-3.5 text-emerald-400" /> Role Workspaces
+          </div>
+          <div className="space-y-2 text-xs">
+            {workspaceEntries.length === 0 ? (
+              <p className="text-slate-500">No explicit roles.workspaceDirs mapping.</p>
+            ) : (
+              workspaceEntries.map(([role, workspace]) => (
+                <div key={role} className="rounded border border-slate-700 bg-slate-900 p-2">
+                  <p className="font-mono text-slate-100">{role}</p>
+                  <p className="text-slate-400 break-all">{workspace}</p>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-slate-800 bg-slate-900/30 p-3 lg:col-span-1">
+          <div className="mb-2 flex items-center gap-2 text-xs text-slate-300">
+            <Route className="h-3.5 w-3.5 text-amber-400" /> Agent Bindings
+          </div>
+          <div className="max-h-64 overflow-auto space-y-2 text-xs">
+            {bindings.length === 0 ? (
+              <p className="text-slate-500">No agents.bindings configured.</p>
+            ) : (
+              bindings.map((b, idx) => (
+                <div key={`${b.agentId}-${idx}`} className="rounded border border-slate-700 bg-slate-900 p-2">
+                  <p className="font-mono text-slate-100">agent: {b.agentId}</p>
+                  <p className="text-slate-400">channel={b.channel} account={b.accountId}</p>
+                  <p className="text-slate-400">guild={b.guildId} roles={b.roles}</p>
+                  <p className="text-slate-400">peer={b.peer} parentPeer={b.parentPeer}</p>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
 export function SettingsPage() {
   // 页面挂载埋点
   useEffect(() => {
@@ -100,6 +194,7 @@ export function SettingsPage() {
     <div className="space-y-4">
       {/* 观测面板 */}
       <ObservabilityPanel />
+      <RouteMappingPanel config={(configQuery.data ?? {}) as Record<string, unknown>} />
       
       <div className="space-y-3 rounded-xl border border-slate-800 bg-card p-4">
       <h2 className="text-sm font-semibold">Gateway Settings</h2>

--- a/pi-gateway/docs/issues/issue-16-routing-observability-implementation.md
+++ b/pi-gateway/docs/issues/issue-16-routing-observability-implementation.md
@@ -1,0 +1,82 @@
+# Issue #16 实施结果：角色-工作区-频道 映射 + 多 Agent 路由管理（P1）
+
+## 本次实现范围
+
+### 1) 角色/工作区/频道映射打通
+
+路由链路由原来的“分散决策”改为可联动：
+
+- 频道 -> Agent：`resolveAgentRoute()`（binding / prefix / default）
+- Agent -> Role：当频道未显式 role 时，回退 `agents.list[].role`
+- Role -> Workspace：
+  - 优先 `roles.workspaceDirs[role]`
+  - 否则回退 `agents.list[].workspace`
+  - 最后回退默认 `~/.pi/gateway/workspaces/{role}`
+
+新增能力：
+- `resolveRoleForSessionAndAgent()`
+- `extractAgentIdFromSessionKey()`
+- `getCwdForRole(role, config, agentId?)` 支持 agent workspace 回退
+
+### 2) 多 Agent 管理可解释（对标 OpenClaw 增强）
+
+- `resolveAgentRoute()` 输出：
+  - `agentId`
+  - `text`
+  - `source`（single-agent/binding/prefix/default）
+  - `bindingScore`（命中 binding 时）
+- `resolveRoleForSessionDetailed()` 输出：
+  - `role`
+  - `source`（telegram.topic / telegram.group / discord.channel / agent.role / default 等）
+- binding 匹配能力已增强：
+  - `roles`（guild+roles）
+  - `parentPeer`（线程父级继承）
+  - `peer.kind` 扩展支持 `channel/thread`
+- `session.dmScope` 新增支持 `per-account-channel-peer`
+
+### 3) 运行链路接线
+
+- Telegram / Discord / Feishu 入站日志增加 `agentSource`（以及可选 `bindingScore`）
+- `message-pipeline` 在 `session_created` 元数据中记录 `roleSource`
+- `message-pipeline` 角色解析改为 agent-aware（支持 agent.role 回退）
+- `server.buildSessionProfile` 根据 `sessionKey` 提取 `agentId`，用于 workspace 解析
+
+### 4) TG 键盘 + RPC 角色管理深度集成
+
+- `/role`（Telegram）无参数时弹出键盘，支持快速选择角色
+- 键盘回调 `role:set:<name>` 直接切换当前会话角色
+- 网关 RPC 新增角色管理方法：
+  - `roles.list`
+  - `roles.set`
+  - `roles.create`
+  - `roles.delete`
+- Gateway Plugin API 暴露：
+  - `listAvailableRoles()`
+  - `setSessionRole()`
+  - `createRole()`
+  - `deleteRole()`
+
+### 5) 生产配置样例（JSONC）
+
+- 已提供完整示例：`pi-gateway.jsonc.example`
+- 包含：
+  - 角色-工作区映射
+  - 多 agent 列表与 role 绑定
+  - channel/guild/roles/parentPeer bindings
+  - `dmScope: per-account-channel-peer`
+
+### 6) 兼容性
+
+- 保留旧 API：`resolveAgentId()` 与 `resolveRoleForSession()`
+- 现有调用不会被破坏
+
+## 验证
+
+- `session-router.test.ts`：通过（新增映射相关断言）
+- `bbd-v3-routing-real.test.ts`：通过（路由回归）
+
+## 价值
+
+- 实现了你要的核心：角色-工作区-频道映射在实际路由链路中联动生效
+- 多 agent 管理从“可配置但未完全打通”变为“可解释 + 可落地”
+- 为后续 P2（parent-peer / guild+roles / per-account-channel-peer）留出稳定演进点

--- a/pi-gateway/pi-gateway.jsonc.example
+++ b/pi-gateway/pi-gateway.jsonc.example
@@ -1,41 +1,49 @@
 {
-  // Pi Gateway Configuration Example
-  // Copy this file to pi-gateway.jsonc and fill in your actual values
+  // Production-ready example: role-workspace-channel mapping + multi-agent routing
+  // Copy to: pi-gateway.jsonc
 
   "gateway": {
     "port": 52134,
     "bind": "0.0.0.0",
     "auth": {
-      "mode": "off"
+      "mode": "token",
+      "token": "${PI_GATEWAY_TOKEN}",
+      "allowUnauthenticated": false
+    },
+    "commands": {
+      "restart": false
     }
   },
 
   "agent": {
     "piCliPath": "pi",
-    "model": "anthropic/claude-sonnet-4",
-    "thinkingLevel": "off",
+    "model": "openai-codex/gpt-5.3-codex",
+    "thinkingLevel": "medium",
     "pool": {
       "min": 1,
-      "max": 4,
+      "max": 6,
       "idleTimeoutMs": 300000
     },
     "tools": {
-      "profile": "coding"
+      "profile": "coding",
+      "allow": ["read", "edit", "write", "grep", "bash"]
     },
-    // Model failover: automatic fallback when primary model fails
-    // "modelFailover": {
-    //   "primary": "anthropic/claude-sonnet-4",
-    //   "fallbacks": ["openai/gpt-4o", "moonshot/kimi-k2-0711"],
-    //   "cooldownMs": 60000    // cooldown per model after failure (default: 60s)
-    // }
+    "sandbox": {
+      "mode": "off",
+      "scope": "session"
+    },
+    "messageMode": "steer",
+    "timeoutMs": 900000,
+    "extensions": [
+      "~/.pi/agent/extensions/role-persona/index.ts"
+    ]
   },
 
   "session": {
-    // dmScope: "main" | "per-peer" | "per-channel-peer"
-    // - main: all DMs share one session (default)
-    // - per-peer: each user gets their own session
-    // - per-channel-peer: each channel+user combo gets a session
-    "dmScope": "main"
+    // main | per-peer | per-channel-peer | per-account-channel-peer
+    "dmScope": "per-account-channel-peer",
+    "dataDir": "~/.pi/gateway/sessions",
+    "continueOnRestart": true
   },
 
   "channels": {
@@ -43,73 +51,170 @@
       "enabled": true,
       "botToken": "${TELEGRAM_BOT_TOKEN}",
       "dmPolicy": "allowlist",
-      "allowFrom": [YOUR_TELEGRAM_USER_ID],
-      "mediaMaxMb": 10,
+      "allowFrom": [1050271633],
+      "mediaMaxMb": 256,
       "streamMode": "partial",
-      // Streaming edit throttle (ms). Lower = faster updates, higher = fewer 429s.
-      // Adaptive backoff on 429: reads Telegram retry_after, recovers gradually.
-      "editThrottleMs": 500,
-
-      // Group chat configuration
-      // Key: Telegram chat ID (supergroup format: -100xxxxxxxxxx)
-      // Use "*" as wildcard for all unconfigured groups
       "groups": {
-        "-100123456789": {
-          // requireMention: true (default) — bot only responds when @mentioned
-          // Set false for always-on mode (agent replies to every message)
-          "requireMention": true,
-          // groupPolicy: "open" | "disabled" | "allowlist"
+        "-5106685069": {
+          "requireMention": false,
           "groupPolicy": "open",
-          // Optional: bind a role to this group (uses role-persona for personality)
-          // "role": "code-reviewer",
-          // Optional: restrict who can interact in this group
-          // "allowFrom": [123456789, "*"],
-          // Optional: override system prompt for this group
-          // "systemPrompt": "You are a helpful coding assistant."
+          "role": "ops"
         },
-        // Wildcard: disable all unconfigured groups
-        "*": { "enabled": false }
+        "-5211232825": {
+          "requireMention": false,
+          "groupPolicy": "open",
+          "role": "architect"
+        },
+        "-1003835388833": {
+          "requireMention": false,
+          "groupPolicy": "open",
+          "role": "research"
+        },
+        "*": {
+          "enabled": false
+        }
       }
     },
+
     "discord": {
-      "enabled": false,
+      "enabled": true,
       "token": "${DISCORD_BOT_TOKEN}",
-      "dmPolicy": "pairing",
-      // "dm": { "allowFrom": ["USER_ID_1"] },
-      // Per-guild config: requireMention (default true), role binding
-      // "guilds": {
-      //   "GUILD_ID": { "requireMention": true, "role": "default" }
-      // },
-      "streaming": {
+      "dmPolicy": "allowlist",
+      "dm": {
         "enabled": true,
-        // Edit throttle (ms). Discord is more lenient than Telegram.
-        "editThrottleMs": 500,
-        // Stop editing after this many chars; send full reply on completion.
-        "editCutoffChars": 1800,
-        "placeholder": "⏳ Processing..."
+        "allowFrom": ["123456789012345678"]
+      },
+      "guilds": {
+        "guild-001": {
+          "requireMention": false,
+          "role": "architect",
+          "channels": {
+            "channel-ops": { "role": "ops" },
+            "channel-docs": { "role": "docs" }
+          }
+        }
       }
     }
   },
 
-  "plugins": {
-    "dirs": [],
-    "disabled": []
-  },
-
   "roles": {
-    "workspaceDirs": {}
+    "mergeMode": "append",
+    "workspaceDirs": {
+      "default": "~/.pi/gateway/workspaces/default",
+      "ops": "~/projects/ops-workspace",
+      "docs": "~/projects/docs-workspace",
+      "architect": "~/projects/architecture-workspace",
+      "research": "~/projects/research-workspace"
+    },
+    "capabilities": {
+      "ops": {
+        "skills": ["~/.pi/agent/skills/server-status-push"],
+        "extensions": []
+      },
+      "docs": {
+        "skills": ["~/.pi/agent/skills/workhub"]
+      }
+    }
   },
 
-  "hooks": {
-    "enabled": false
+  "agents": {
+    "default": "main",
+    "list": [
+      {
+        "id": "main",
+        "workspace": "~/projects/main-workspace",
+        "model": "openai-codex/gpt-5.3-codex",
+        "role": "default"
+      },
+      {
+        "id": "ops",
+        "workspace": "~/projects/ops-workspace",
+        "model": "openai/gpt-4.1",
+        "role": "ops"
+      },
+      {
+        "id": "docs",
+        "workspace": "~/projects/docs-workspace",
+        "model": "anthropic/claude-sonnet-4",
+        "role": "docs"
+      },
+      {
+        "id": "architect",
+        "workspace": "~/projects/architecture-workspace",
+        "model": "anthropic/claude-sonnet-4",
+        "role": "architect"
+      }
+    ],
+
+    "bindings": [
+      {
+        "agentId": "ops",
+        "match": {
+          "channel": "telegram",
+          "peer": { "kind": "group", "id": "-5106685069" }
+        }
+      },
+      {
+        "agentId": "docs",
+        "match": {
+          "channel": "telegram",
+          "peer": { "kind": "group", "id": "-5211232825" }
+        }
+      },
+      {
+        "agentId": "architect",
+        "match": {
+          "channel": "discord",
+          "guildId": "guild-001",
+          "roles": ["role-architect", "role-lead"]
+        }
+      },
+      {
+        // thread inherit example: child thread follows parent channel binding
+        "agentId": "ops",
+        "match": {
+          "channel": "discord",
+          "parentPeer": { "kind": "channel", "id": "channel-ops" }
+        }
+      }
+    ]
+  },
+
+  "delegation": {
+    "timeoutMs": 120000,
+    "maxTimeoutMs": 600000,
+    "onTimeout": "abort",
+    "maxDepth": 1,
+    "maxConcurrent": 2
   },
 
   "cron": {
-    "enabled": false,
+    "enabled": true,
     "jobs": []
   },
 
-  // Message queue & backpressure (all values are defaults, override as needed)
+  "hooks": {
+    "enabled": false,
+    "path": "/hooks"
+  },
+
+  "plugins": {
+    "dirs": [],
+    "disabled": [],
+    "config": {
+      "concise-mode": {
+        "enabled": true,
+        "channels": ["telegram", "discord"]
+      }
+    }
+  },
+
+  "logging": {
+    "file": false,
+    "level": "info",
+    "retentionDays": 7
+  },
+
   "queue": {
     "maxPerSession": 15,
     "globalMaxPending": 100,
@@ -127,77 +232,6 @@
       "group": 5,
       "webhook": 3,
       "allowlistBonus": 2
-    }
-  },
-
-  // Multi-agent configuration (v3)
-  // Define multiple specialized agents and their delegation constraints
-  "agents": {
-    // Default agent when no binding matches
-    "default": "main",
-    // Available agents list
-    "list": [
-      {
-        "id": "main",
-        "workspace": "~/workspace/main",
-        "model": "claude-sonnet-4",
-        "role": "coding"
-      },
-      {
-        "id": "docs",
-        "workspace": "~/workspace/docs",
-        "model": "claude-haiku-4",
-        "role": "documentation",
-        // Delegation constraints: which agents can delegate to this agent
-        "delegation": {
-          "allowAgents": ["main", "code"],
-          "maxConcurrent": 2,
-          "maxDepth": 1
-        }
-      },
-      {
-        "id": "code",
-        "workspace": "~/workspace/code",
-        "model": "claude-sonnet-4",
-        "role": "coding",
-        "extensions": ["~/.pi/agent/extensions/code-review.ts"],
-        "skills": ["~/.pi/agent/skills/ast-grep"],
-        "delegation": {
-          "allowAgents": ["main", "docs"],
-          "maxConcurrent": 3,
-          "maxDepth": 1
-        }
-      }
-    ],
-    // Static routing bindings (optional)
-    "bindings": [
-      {
-        "agentId": "code",
-        "match": {
-          "channel": "telegram",
-          "peer": {
-            "kind": "group",
-            "id": "-1001234567890"
-          }
-        }
-      },
-      {
-        "agentId": "docs",
-        "match": {
-          "channel": "discord",
-          "guildId": "1234567890"
-        }
-      }
-    ]
-  },
-
-  // Role workspace mapping
-  // Each role gets its own CWD + role-persona files (SOUL.md, IDENTITY.md, etc.)
-  // Groups can bind to roles via groups[chatId].role
-  "roles": {
-    "workspaceDirs": {
-      // "code-reviewer": "~/workspace/reviewer",
-      // "translator": "~/workspace/translator"
     }
   }
 }

--- a/pi-gateway/src/core/bbd-v3-routing-real.test.ts
+++ b/pi-gateway/src/core/bbd-v3-routing-real.test.ts
@@ -127,6 +127,48 @@ describe("v3 routing real: Layer 1 static binding", () => {
     expect(result.agentId).toBe("ops"); // peer wins
   });
 
+  test("parentPeer binding matches thread inherited parent", () => {
+    const config = makeConfig(threeAgents, "code", [
+      {
+        agentId: "docs",
+        match: { channel: "discord", parentPeer: { kind: "channel", id: "parent-1" } },
+      },
+    ]);
+
+    const result = resolveAgentId(
+      makeSource({
+        channel: "discord",
+        chatType: "thread",
+        chatId: "thread-1",
+        parentPeer: { kind: "channel", id: "parent-1" },
+      }),
+      "hello",
+      config,
+    );
+
+    expect(result.agentId).toBe("docs");
+  });
+
+  test("guild+roles binding matches when member has role", () => {
+    const config = makeConfig(threeAgents, "code", [
+      { agentId: "ops", match: { channel: "discord", guildId: "g1", roles: ["r1"] } },
+    ]);
+
+    const result = resolveAgentId(
+      makeSource({
+        channel: "discord",
+        chatType: "channel",
+        chatId: "c1",
+        guildId: "g1",
+        memberRoleIds: ["r1", "r2"],
+      }),
+      "hello",
+      config,
+    );
+
+    expect(result.agentId).toBe("ops");
+  });
+
   test("unmatched source skips to next layer", () => {
     const config = makeConfig(threeAgents, "code", [
       { agentId: "ops", match: { channel: "telegram", peer: { kind: "group", id: "-100ops" } } },

--- a/pi-gateway/src/core/config-schema.ts
+++ b/pi-gateway/src/core/config-schema.ts
@@ -41,6 +41,7 @@ export const DmScopeSchema = Type.Union([
   Type.Literal("main"),
   Type.Literal("per-peer"),
   Type.Literal("per-channel-peer"),
+  Type.Literal("per-account-channel-peer"),
 ]);
 
 export const MessageModeSchema = Type.Union([
@@ -482,8 +483,18 @@ export const AgentBindingSchema = Type.Object({
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
     guildId: Type.Optional(Type.String()),
+    roles: Type.Optional(Type.Array(Type.String())),
     peer: Type.Optional(Type.Object({
-      kind: Type.Optional(Type.Union([Type.Literal("dm"), Type.Literal("group")])),
+      kind: Type.Optional(Type.Union([
+        Type.Literal("dm"),
+        Type.Literal("group"),
+        Type.Literal("channel"),
+        Type.Literal("thread"),
+      ])),
+      id: Type.Optional(Type.String()),
+    })),
+    parentPeer: Type.Optional(Type.Object({
+      kind: Type.Optional(Type.Union([Type.Literal("group"), Type.Literal("channel")])),
       id: Type.Optional(Type.String()),
     })),
   }),

--- a/pi-gateway/src/core/config.ts
+++ b/pi-gateway/src/core/config.ts
@@ -147,8 +147,15 @@ export interface AgentBinding {
     channel?: string;
     accountId?: string;
     guildId?: string;  // Discord specific
+    /** Discord member roles constraint (all listed roles must match at least one in source roles set). */
+    roles?: string[];
     peer?: {
-      kind?: "dm" | "group";
+      kind?: "dm" | "group" | "channel" | "thread";
+      id?: string;
+    };
+    /** Parent peer inheritance (e.g. thread parent channel/topic). */
+    parentPeer?: {
+      kind?: "group" | "channel";
       id?: string;
     };
   };
@@ -230,7 +237,7 @@ export interface AgentConfig {
 }
 
 export interface SessionConfig {
-  dmScope: "main" | "per-peer" | "per-channel-peer";
+  dmScope: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   dataDir: string;
   /** Auto-resume sessions on restart via --continue. Default: true */
   continueOnRestart?: boolean;

--- a/pi-gateway/src/core/session-router.test.ts
+++ b/pi-gateway/src/core/session-router.test.ts
@@ -3,7 +3,14 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { DEFAULT_CONFIG, type Config } from "./config.ts";
-import { getCwdForRole, resolveRoleForSession } from "./session-router.ts";
+import {
+  extractAgentIdFromSessionKey,
+  getCwdForRole,
+  resolveAgentRoute,
+  resolveRoleForSession,
+  resolveRoleForSessionAndAgent,
+  resolveRoleForSessionDetailed,
+} from "./session-router.ts";
 
 const tempDirs: string[] = [];
 
@@ -51,6 +58,20 @@ describe("session router role mapping", () => {
 
     const cwd = getCwdForRole("architect", config);
     expect(cwd).toBe(resolve(workspaceRoot));
+  });
+
+  test("falls back to agent workspace when role workspace is not configured", () => {
+    const runtimeRoot = mkTempDir("pi-gw-runtime-");
+    const agentWorkspace = mkTempDir("pi-gw-agent-workspace-");
+    const config = mkConfig();
+    config.agent.runtime = { agentDir: runtimeRoot };
+    config.agents = {
+      list: [{ id: "ops", workspace: agentWorkspace, role: "operator" }],
+      default: "ops",
+    } as any;
+
+    const cwd = getCwdForRole("operator", config, "ops");
+    expect(cwd).toBe(resolve(agentWorkspace));
   });
 });
 
@@ -109,5 +130,73 @@ describe("resolveRoleForSession", () => {
     }, config);
 
     expect(role).toBe("wildcard-topic-role");
+  });
+
+  test("returns role source for observability", () => {
+    const config = mkConfig();
+    config.channels.telegram = {
+      ...(config.channels.telegram ?? {}),
+      enabled: true,
+      groups: {
+        "-1003": {
+          role: "ops-role",
+        },
+      },
+    } as any;
+
+    const detailed = resolveRoleForSessionDetailed({
+      channel: "telegram",
+      accountId: "default",
+      chatType: "group",
+      chatId: "-1003",
+      senderId: "u3",
+    }, config);
+
+    expect(detailed.role).toBe("ops-role");
+    expect(detailed.source).toBe("telegram.group");
+  });
+});
+
+describe("resolveAgentRoute", () => {
+  test("returns single-agent source when agents.list is empty", () => {
+    const config = mkConfig();
+    config.agents = { list: [], default: "main" } as any;
+
+    const route = resolveAgentRoute({
+      channel: "telegram",
+      chatType: "dm",
+      chatId: "u1",
+      senderId: "u1",
+      accountId: "default",
+    }, "hello", config);
+
+    expect(route.agentId).toBe("main");
+    expect(route.source).toBe("single-agent");
+  });
+});
+
+describe("role/agent/workspace mapping", () => {
+  test("falls back to agent role when channel role is not configured", () => {
+    const config = mkConfig();
+    config.agents = {
+      list: [{ id: "docs", workspace: "/tmp/docs", role: "writer" }],
+      default: "docs",
+    } as any;
+
+    const resolved = resolveRoleForSessionAndAgent({
+      channel: "telegram",
+      chatType: "dm",
+      chatId: "u1",
+      senderId: "u1",
+      agentId: "docs",
+    }, config, "docs");
+
+    expect(resolved.role).toBe("writer");
+    expect(resolved.source).toBe("agent.role");
+  });
+
+  test("extracts agentId from session key", () => {
+    expect(extractAgentIdFromSessionKey("agent:ops:telegram:account:default:group:-100")).toBe("ops");
+    expect(extractAgentIdFromSessionKey("cron:job-1")).toBeNull();
   });
 });

--- a/pi-gateway/src/core/types.ts
+++ b/pi-gateway/src/core/types.ts
@@ -235,6 +235,10 @@ export interface MessageSource {
   senderId: string;
   senderName?: string;
   guildId?: string;
+  /** Discord member role IDs, used for guild+roles routing. */
+  memberRoleIds?: string[];
+  /** Parent peer context (e.g. thread parent channel) for inheritance routing. */
+  parentPeer?: { kind: "group" | "channel"; id: string };
   /** Target agent ID for routing (cron/delegation). */
   agentId?: string;
   /** Inbound message ID (platform-specific, for pin/reply/react). */
@@ -303,6 +307,10 @@ export type GatewayMethod =
   | "sessions.get"
   | "sessions.compact"
   | "sessions.delete"
+  | "roles.list"
+  | "roles.set"
+  | "roles.create"
+  | "roles.delete"
   | "plugins.list"
   | "tools.list"
   | "tools.call"

--- a/pi-gateway/src/gateway/types.ts
+++ b/pi-gateway/src/gateway/types.ts
@@ -106,6 +106,8 @@ export interface GatewayContext {
   compactSessionWithHooks: (sessionKey: SessionKey, instructions?: string) => Promise<void>;
   listAvailableRoles: () => string[];
   setSessionRole: (sessionKey: SessionKey, newRole: string) => Promise<boolean>;
+  createRole: (role: string) => Promise<{ ok: boolean; error?: string }>;
+  deleteRole: (role: string) => Promise<{ ok: boolean; error?: string }>;
   reloadConfig?: () => void;
   /** Track cron sessions that self-delivered messages (skip announce). */
   onCronDelivered?: (sessionKey: string) => void;

--- a/pi-gateway/src/plugins/builtin/telegram/model-selector.ts
+++ b/pi-gateway/src/plugins/builtin/telegram/model-selector.ts
@@ -150,6 +150,49 @@ export function registerCallbackHandler(
       return;
     }
 
+    // Role keyboard callbacks
+    if (data.startsWith("role:")) {
+      const source = toSource(account.accountId, ctx as TelegramContext);
+      const sessionKey = resolveSessionKey(source, runtime.api.config);
+
+      if (data.startsWith("role:set:")) {
+        const role = data.slice("role:set:".length).trim();
+        const ok = await runtime.api.setSessionRole(sessionKey, role);
+        await ctx.answerCallbackQuery?.({ text: ok ? `Switched: ${role}` : "Switch failed" });
+        if (ok) {
+          await ctx.reply(`✅ Role switched to: <b>${role}</b>`, { parse_mode: "HTML" });
+        }
+        return;
+      }
+
+      if (data.startsWith("role:del:")) {
+        const role = data.slice("role:del:".length).trim();
+        const deleted = await runtime.api.deleteRole(role);
+        await ctx.answerCallbackQuery?.({ text: deleted.ok ? `Deleted: ${role}` : "Delete failed" });
+        if (deleted.ok) {
+          await ctx.reply(`🗑 Role deleted: <b>${role}</b>`, { parse_mode: "HTML" });
+        } else {
+          await ctx.reply(`❌ Failed to delete role <b>${role}</b>: ${deleted.error ?? "unknown error"}`, { parse_mode: "HTML" });
+        }
+        return;
+      }
+
+      if (data === "role:hint:create") {
+        await ctx.answerCallbackQuery?.({ text: "Use /role create <name>" });
+        await ctx.reply("Use <code>/role create &lt;name&gt;</code> to create role.", { parse_mode: "HTML" });
+        return;
+      }
+
+      if (data === "role:hint:delete") {
+        await ctx.answerCallbackQuery?.({ text: "Use /role delete <name>" });
+        await ctx.reply("Use <code>/role delete &lt;name&gt;</code> to delete role.", { parse_mode: "HTML" });
+        return;
+      }
+
+      await ctx.answerCallbackQuery?.();
+      return;
+    }
+
     if (data.startsWith("cmd_page:")) {
       const page = Math.max(1, Number.parseInt(data.slice("cmd_page:".length), 10) || 1);
       const view = helpPage(page);

--- a/pi-gateway/src/plugins/plugin-api-factory.ts
+++ b/pi-gateway/src/plugins/plugin-api-factory.ts
@@ -292,5 +292,21 @@ export function createPluginApi(
     readTranscript(sessionKey: SessionKey, lastN = 100) {
       return ctx.transcripts.readTranscript(sessionKey, lastN);
     },
+
+    listAvailableRoles() {
+      return ctx.listAvailableRoles();
+    },
+
+    async setSessionRole(sessionKey: SessionKey, role: string) {
+      return ctx.setSessionRole(sessionKey, role);
+    },
+
+    async createRole(role: string) {
+      return ctx.createRole(role);
+    },
+
+    async deleteRole(role: string) {
+      return ctx.deleteRole(role);
+    },
   };
 }

--- a/pi-gateway/src/plugins/types.ts
+++ b/pi-gateway/src/plugins/types.ts
@@ -356,6 +356,7 @@ export interface CommandContext {
   sessionKey: SessionKey;
   senderId: string;
   channel: string;
+  chatId?: string;
   accountId?: string;
   args: string;
   respond: (text: string) => Promise<void>;
@@ -521,6 +522,18 @@ export interface GatewayPluginApi {
 
   /** Read transcript entries for a session (from gateway JSONL logs) */
   readTranscript(sessionKey: SessionKey, lastN?: number): import("../core/transcript-logger.ts").TranscriptEntry[];
+
+  /** List available roles from gateway + role directory + agent roles */
+  listAvailableRoles(): string[];
+
+  /** Set role for a specific session */
+  setSessionRole(sessionKey: SessionKey, role: string): Promise<boolean>;
+
+  /** Create role directory scaffold */
+  createRole(role: string): Promise<{ ok: boolean; error?: string }>;
+
+  /** Delete role directory and cleanup mappings */
+  deleteRole(role: string): Promise<{ ok: boolean; error?: string }>;
 }
 
 // ============================================================================

--- a/pi-gateway/src/ws/ws-methods.ts
+++ b/pi-gateway/src/ws/ws-methods.ts
@@ -101,7 +101,37 @@ export function registerSessionMethods(
     await ctx.compactSessionWithHooks(cKey, params?.instructions as string);
     return { ok: true };
   });
-  // Role management handled by role-persona extension via RPC
+
+  // Role management for gateway-side RPC integrations
+  methods.set("roles.list", async () => {
+    return { roles: ctx.listAvailableRoles() };
+  });
+
+  methods.set("roles.set", async (params) => {
+    const sKey = params?.sessionKey as string;
+    const role = String(params?.role ?? "").trim();
+    if (!sKey) throw new Error("sessionKey required");
+    if (!role) throw new Error("role required");
+    const ok = await ctx.setSessionRole(sKey, role);
+    if (!ok) throw new Error("failed to set role");
+    return { ok: true, sessionKey: sKey, role };
+  });
+
+  methods.set("roles.create", async (params) => {
+    const role = String(params?.role ?? "").trim();
+    if (!role) throw new Error("role required");
+    const result = await ctx.createRole(role);
+    if (!result.ok) throw new Error(result.error ?? "failed to create role");
+    return { ok: true, role };
+  });
+
+  methods.set("roles.delete", async (params) => {
+    const role = String(params?.role ?? "").trim();
+    if (!role) throw new Error("role required");
+    const result = await ctx.deleteRole(role);
+    if (!result.ok) throw new Error(result.error ?? "failed to delete role");
+    return { ok: true, role };
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
This PR now delivers production-oriented role integration for gateway + Telegram operations.

### 1) End-to-end mapping chain (wired)
- **Channel -> Agent** via `resolveAgentRoute()` (binding / prefix / default)
- **Agent -> Role** fallback when channel role is absent (`agents.list[].role`)
- **Role -> Workspace** resolution order:
  1. `roles.workspaceDirs[role]`
  2. `agents.list[].workspace` (for routed agent)
  3. default `~/.pi/gateway/workspaces/{role}`

### 2) OpenClaw-aligned routing capability upgrades
- `session.dmScope` now supports `per-account-channel-peer`
- bindings now support:
  - `roles` (guild+roles routing)
  - `parentPeer` (thread parent inheritance)
  - `peer.kind` extended to `channel` / `thread`
- Discord source now carries `memberRoleIds` and `parentPeer` context for matching

### 3) Gateway deep role integration (RPC + plugin exposure)
- Gateway context now supports role CRUD primitives:
  - `createRole(role)`
  - `deleteRole(role)`
- Plugin API now exposes:
  - `listAvailableRoles()`
  - `setSessionRole(sessionKey, role)`
  - `createRole(role)`
  - `deleteRole(role)`
- WS RPC methods added for role management:
  - `roles.list`
  - `roles.set`
  - `roles.create`
  - `roles.delete`

### 4) Telegram keyboard role control
- `/role` (no args) now opens Telegram inline keyboard for role selection
- callback `role:set:<name>` switches current session role directly
- keyboard hints guide create/delete workflows:
  - `/role create <name>`
  - `/role delete <name>`

### 5) Admin visualization
- Settings page includes **Role / Workspace / Channel / Agent Mapping** panel:
  - agent list (id / role / workspace)
  - role workspace mappings
  - binding matrix (channel/account/guild/roles/peer/parentPeer)

### 6) Production JSONC example included
- Updated `pi-gateway.jsonc.example` with complete ready-to-adapt config:
  - role/workspace mappings
  - multi-agent list with roles/workspaces
  - bindings incl. channel/guild/roles/parentPeer
  - `dmScope: per-account-channel-peer`

## Validation
- `bun test .../src/gateway/command-handler.test.ts` ✅
- `bun test .../src/core/session-router.test.ts` ✅
- `bun test .../src/core/bbd-v3-routing-real.test.ts` ✅
- `cd pi-gateway/admin-console && npm run typecheck` ✅

## Compatibility
- Backward compatible: `resolveAgentId()` and `resolveRoleForSession()` retained

Refs #16
