### PR TITLE
fix(pi-gateway): route telegram outbound by session account/topic target

### DIFF
--- a/pi-gateway/src/api/channel-target.ts
+++ b/pi-gateway/src/api/channel-target.ts
@@ -1,0 +1,22 @@
+import type { SessionState } from "../core/types.ts";
+
+/**
+ * Resolve outbound channel target from session state.
+ *
+ * - Default: plain chatId
+ * - Telegram: "{accountId}:{chatId}[:topic:{topicId}]"
+ */
+export function resolveChannelTarget(
+  channel: string,
+  chatId: string,
+  sessionKey?: string,
+  session?: SessionState,
+): string {
+  if (channel !== "telegram") return chatId;
+
+  const accountFromKey = sessionKey?.match(/^agent:[^:]+:telegram:account:([^:]+):/)?.[1];
+  const accountId = session?.lastAccountId || accountFromKey || "default";
+  const topicId = session?.lastTopicId;
+
+  return `${accountId}:${chatId}${topicId ? `:topic:${topicId}` : ""}`;
+}

--- a/pi-gateway/src/api/keyboard-interact.ts
+++ b/pi-gateway/src/api/keyboard-interact.ts
@@ -26,6 +26,7 @@ import type { RpcPool } from "../core/rpc-pool.ts";
 import type { PluginRegistryState } from "../plugins/loader.ts";
 import type { SessionStore } from "../core/session-store.ts";
 import { getGatewayInternalToken } from "./media-send.ts";
+import { resolveChannelTarget } from "./channel-target.ts";
 
 // ============================================================================
 // Types
@@ -183,6 +184,8 @@ export async function handleKeyboardRequest(
   if (!channel) return Response.json({ error: "Cannot resolve channel" }, { status: 400 });
   if (!chatId) return Response.json({ error: "Cannot resolve chatId" }, { status: 400 });
 
+  const target = resolveChannelTarget(channel, chatId, sessionKey, session);
+
   const channelPlugin = ctx.registry.channels.get(channel);
   if (!channelPlugin) return Response.json({ error: `Channel not found: ${channel}` }, { status: 404 });
   if (!channelPlugin.outbound.sendKeyboard) {
@@ -208,7 +211,7 @@ export async function handleKeyboardRequest(
   if (currentRow.length > 0) rows.push(currentRow);
 
   // Send keyboard via channel outbound
-  const sendResult = await channelPlugin.outbound.sendKeyboard(chatId, title, { inline_keyboard: rows });
+  const sendResult = await channelPlugin.outbound.sendKeyboard(target, title, { inline_keyboard: rows });
   if (!sendResult.ok) {
     return Response.json({ error: sendResult.error ?? "Failed to send keyboard" }, { status: 500 });
   }
@@ -221,7 +224,7 @@ export async function handleKeyboardRequest(
       pending.delete(requestId);
       // Edit message to show timeout
       if (messageId && channelPlugin.outbound.editMessageMarkup) {
-        channelPlugin.outbound.editMessageMarkup(chatId, messageId, `⏰ ${title}\n<i>(timed out)</i>`).catch(() => {});
+        channelPlugin.outbound.editMessageMarkup(target, messageId, `⏰ ${title}\n<i>(timed out)</i>`).catch(() => {});
       }
       resolve({ ok: false, error: "timeout" });
     }, timeoutMs);
@@ -241,7 +244,7 @@ export async function handleKeyboardRequest(
   // Edit message to show selection result (remove keyboard)
   if (result.ok && result.selected && messageId && channelPlugin.outbound.editMessageMarkup) {
     channelPlugin.outbound.editMessageMarkup(
-      chatId, messageId,
+      target, messageId,
       `${title}\n\n✅ <b>${result.selected.text}</b>`,
     ).catch(() => {});
   }

--- a/pi-gateway/src/api/media-send.ts
+++ b/pi-gateway/src/api/media-send.ts
@@ -17,6 +17,7 @@ import type { RpcPool } from "../core/rpc-pool.ts";
 import type { Logger } from "../core/types.ts";
 import type { PluginRegistryState } from "../plugins/loader.ts";
 import type { SessionStore } from "../core/session-store.ts";
+import { resolveChannelTarget } from "./channel-target.ts";
 
 /** Allowed absolute path prefixes for agent tool calls (send_media). */
 const ALLOWED_ABSOLUTE_PREFIXES = [
@@ -213,10 +214,12 @@ export async function handleMediaSendRequest(
     return Response.json({ error: "Cannot resolve chatId — no messages received in this session yet" }, { status: 400 });
   }
 
-  ctx.log.info(`[media-send] direct delivery: channel=${channel} chatId=${chatId} path=${filePath} type=${resolvedType}`);
+  const target = resolveChannelTarget(channel, chatId, sessionKey, session);
+
+  ctx.log.info(`[media-send] direct delivery: channel=${channel} target=${target} path=${filePath} type=${resolvedType}`);
 
   try {
-    const result = await channelPlugin.outbound.sendMedia(chatId, fullPath, {
+    const result = await channelPlugin.outbound.sendMedia(target, fullPath, {
       type: resolvedType as "photo" | "audio" | "document" | "video" | "sticker",
       caption,
     });

--- a/pi-gateway/src/api/message-action.ts
+++ b/pi-gateway/src/api/message-action.ts
@@ -13,6 +13,7 @@ import type { RpcPool } from "../core/rpc-pool.ts";
 import type { PluginRegistryState } from "../plugins/loader.ts";
 import type { SessionStore } from "../core/session-store.ts";
 import { getGatewayInternalToken } from "./media-send.ts";
+import { resolveChannelTarget } from "./channel-target.ts";
 
 export interface MessageActionContext {
   config: Config;
@@ -102,12 +103,14 @@ export async function handleMessageAction(
     return Response.json({ error: "Cannot resolve chatId from session" }, { status: 400 });
   }
 
+  const target = resolveChannelTarget(channel, chatId, sessionKey, session);
+
   const channelPlugin = ctx.registry.channels.get(channel);
   if (!channelPlugin) {
     return Response.json({ error: `Channel plugin not found: ${channel}` }, { status: 404 });
   }
 
-  ctx.log.info(`[message-action] ${action} channel=${channel} chatId=${chatId} messageId=${messageId}`);
+  ctx.log.info(`[message-action] ${action} channel=${channel} target=${target} messageId=${messageId}`);
 
   try {
     if (action === "react") {
@@ -118,7 +121,7 @@ export async function handleMessageAction(
         ? body.emoji.filter((e): e is string => typeof e === "string" && e.trim() !== "")
         : typeof body.emoji === "string" ? body.emoji.trim() : "";
       const remove = body.remove === true;
-      const result = await channelPlugin.outbound.sendReaction(chatId, messageId, emoji, { remove });
+      const result = await channelPlugin.outbound.sendReaction(target, messageId, emoji, { remove });
       if (!result.ok) {
         return Response.json({ error: result.error ?? "Reaction failed" }, { status: 502 });
       }
@@ -130,7 +133,7 @@ export async function handleMessageAction(
         return Response.json({ error: `Channel "${channel}" does not support message editing` }, { status: 501 });
       }
       const text = typeof body.text === "string" ? body.text : "";
-      const result = await channelPlugin.outbound.editMessage(chatId, messageId, text);
+      const result = await channelPlugin.outbound.editMessage(target, messageId, text);
       if (!result.ok) {
         return Response.json({ error: result.error ?? "Edit failed" }, { status: 502 });
       }
@@ -141,7 +144,7 @@ export async function handleMessageAction(
       if (!channelPlugin.outbound.deleteMessage) {
         return Response.json({ error: `Channel "${channel}" does not support message deletion` }, { status: 501 });
       }
-      const result = await channelPlugin.outbound.deleteMessage(chatId, messageId);
+      const result = await channelPlugin.outbound.deleteMessage(target, messageId);
       if (!result.ok) {
         return Response.json({ error: result.error ?? "Delete failed" }, { status: 502 });
       }
@@ -153,7 +156,7 @@ export async function handleMessageAction(
         return Response.json({ error: `Channel "${channel}" does not support pinning` }, { status: 501 });
       }
       const unpin = body.unpin === true;
-      const result = await channelPlugin.outbound.pinMessage(chatId, messageId, unpin);
+      const result = await channelPlugin.outbound.pinMessage(target, messageId, unpin);
       if (!result.ok) {
         return Response.json({ error: result.error ?? "Pin failed" }, { status: 502 });
       }
@@ -166,7 +169,7 @@ export async function handleMessageAction(
       }
       const limit = typeof body.limit === "number" ? Math.min(body.limit, 100) : 20;
       const before = typeof body.before === "string" ? body.before : undefined;
-      const result = await channelPlugin.outbound.readHistory(chatId, limit, before);
+      const result = await channelPlugin.outbound.readHistory(target, limit, before);
       if (!result.ok) {
         return Response.json({ error: result.error ?? "Read history failed" }, { status: 502 });
       }

--- a/pi-gateway/src/api/message-edit.ts
+++ b/pi-gateway/src/api/message-edit.ts
@@ -13,6 +13,7 @@ import type { RpcPool } from "../core/rpc-pool.ts";
 import type { PluginRegistryState } from "../plugins/loader.ts";
 import type { SessionStore } from "../core/session-store.ts";
 import { getGatewayInternalToken } from "./media-send.ts";
+import { resolveChannelTarget } from "./channel-target.ts";
 
 export interface MessageEditContext {
   config: Config;
@@ -81,6 +82,8 @@ export async function handleMessageEditRequest(
     return Response.json({ error: "Cannot resolve chatId" }, { status: 400 });
   }
 
+  const target = resolveChannelTarget(channel, chatId, sessionKey, session);
+
   const channelPlugin = ctx.registry.channels.get(channel);
   if (!channelPlugin) {
     return Response.json({ error: `Channel plugin not found: ${channel}` }, { status: 404 });
@@ -92,10 +95,10 @@ export async function handleMessageEditRequest(
     return Response.json({ error: `Channel ${channel} does not support message editing` }, { status: 400 });
   }
 
-  ctx.log.debug(`[message-edit] channel=${channel} chatId=${chatId} messageId=${messageId} text=${text.length} chars`);
+  ctx.log.debug(`[message-edit] channel=${channel} target=${target} messageId=${messageId} text=${text.length} chars`);
 
   try {
-    await channelPlugin.outbound.editMessage(chatId, messageId, text);
+    await channelPlugin.outbound.editMessage(target, messageId, text);
 
     return Response.json({
       ok: true,

--- a/pi-gateway/src/api/message-send.ts
+++ b/pi-gateway/src/api/message-send.ts
@@ -13,6 +13,7 @@ import type { RpcPool } from "../core/rpc-pool.ts";
 import type { PluginRegistryState } from "../plugins/loader.ts";
 import type { SessionStore } from "../core/session-store.ts";
 import { getGatewayInternalToken } from "./media-send.ts";
+import { resolveChannelTarget } from "./channel-target.ts";
 
 export interface MessageSendContext {
   config: Config;
@@ -84,13 +85,15 @@ export async function handleMessageSendRequest(
     return Response.json({ error: "Cannot resolve chatId — no messages received in this session yet" }, { status: 400 });
   }
 
+  const target = resolveChannelTarget(channel, chatId, sessionKey, session);
+
   // Find channel plugin
   const channelPlugin = ctx.registry.channels.get(channel);
   if (!channelPlugin) {
     return Response.json({ error: `Channel plugin not found: ${channel}` }, { status: 404 });
   }
 
-  ctx.log.info(`[message-send] channel=${channel} chatId=${chatId} text=${text.length} chars replyTo=${replyTo ?? "none"}`);
+  ctx.log.info(`[message-send] channel=${channel} target=${target} text=${text.length} chars replyTo=${replyTo ?? "none"}`);
 
   // Tool hook integration for send_message
   const toolInterceptor = new ToolCallInterceptor(ctx, sessionKey);
@@ -120,7 +123,7 @@ export async function handleMessageSendRequest(
       return Response.json({ ok: true, channel, textLength: text.length, delivered: true });
     }
 
-    const result = await channelPlugin.outbound.sendText(chatId, text, { replyTo, parseMode });
+    const result = await channelPlugin.outbound.sendText(target, text, { replyTo, parseMode });
 
     await toolInterceptor.afterCall({ ok: result.ok, textLength: text.length, messageId: result.messageId }, false);
 


### PR DESCRIPTION
## Summary
Fix Telegram multi-account "串号" by ensuring API outbound calls use account-aware targets instead of bare `chatId`.

## Root Cause
Session state already stores Telegram account/topic info, but several API handlers passed only `chatId` to channel outbound APIs. Telegram outbound parser expects `accountId:chatId[:topic:id]`, so account context was lost and messages could be sent by the wrong bot.

## Changes
- Added `src/api/channel-target.ts`
  - `resolveChannelTarget(channel, chatId, sessionKey, session)`
  - Telegram target format: `{accountId}:{chatId}[:topic:{topicId}]`
- Updated handlers to use resolved `target`:
  - `src/api/message-send.ts`
  - `src/api/media-send.ts`
  - `src/api/message-action.ts`
  - `src/api/message-edit.ts`
  - `src/api/keyboard-interact.ts`

## Impact
- Preserves account isolation for Telegram multi-account deployments
- Preserves topic routing in forum chats
- Prevents cross-bot outbound delivery for send/edit/media/action/keyboard flows

## Validation
- Code-level verification of all outbound callsites now using `target`
- `bun run check` currently fails in this environment due missing `bun-types` type defs, unrelated to this patch
