### PR TITLE
feat(pi-gateway): per-channel/group/topic model routing

### DIFF
--- a/pi-gateway/src/api/session-api.ts
+++ b/pi-gateway/src/api/session-api.ts
@@ -201,6 +201,8 @@ export async function handleSessionStatus(
       lastActivity: session?.lastActivity ?? null,
       resolvedModel: session?.lastModel ?? null,
       resolvedModelSource: session?.lastModelSource ?? null,
+      resolvedThinkingLevel: session?.lastThinkingLevel ?? null,
+      resolvedThinkingSource: session?.lastThinkingLevelSource ?? null,
     });
   } catch (err: unknown) {
     return Response.json({ error: (err instanceof Error ? err.message : String(err)) }, { status: 500 });

--- a/pi-gateway/src/core/config-schema.ts
+++ b/pi-gateway/src/core/config-schema.ts
@@ -215,6 +215,7 @@ export const TelegramTopicConfigSchema = Type.Object({
   requireMention: Type.Optional(Type.Boolean()),
   role: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(ThinkingLevelSchema),
   groupPolicy: Type.Optional(GroupPolicySchema),
   enabled: Type.Optional(Type.Boolean()),
   allowFrom: Type.Optional(Type.Array(Type.Union([Type.String(), Type.Integer()]))),
@@ -226,6 +227,7 @@ export const TelegramGroupConfigSchema = Type.Object({
   requireMention: Type.Optional(Type.Boolean()),
   role: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(ThinkingLevelSchema),
   groupPolicy: Type.Optional(GroupPolicySchema),
   enabled: Type.Optional(Type.Boolean()),
   allowFrom: Type.Optional(Type.Array(Type.Union([Type.String(), Type.Integer()]))),
@@ -275,6 +277,7 @@ export const TelegramAccountConfigSchema = Type.Object({
   messageMode: Type.Optional(MessageModeSchema),
   role: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(ThinkingLevelSchema),
   groups: Type.Optional(Type.Record(Type.String(), TelegramGroupConfigSchema)),
   mediaMaxMb: Type.Optional(Type.Number({ minimum: 0.1, maximum: 50 })),
   audio: Type.Optional(TelegramAudioConfigSchema),
@@ -311,9 +314,11 @@ export const DiscordGuildConfigSchema = Type.Object({
   requireMention: Type.Optional(Type.Boolean()),
   role: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(ThinkingLevelSchema),
   channels: Type.Optional(Type.Record(Type.String(), Type.Object({
     role: Type.Optional(Type.String()),
     model: Type.Optional(Type.String()),
+    thinkingLevel: Type.Optional(ThinkingLevelSchema),
   }))),
 });
 
@@ -323,6 +328,7 @@ export const DiscordChannelConfigSchema = Type.Object({
   dmPolicy: Type.Optional(DmPolicySchema),
   role: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(ThinkingLevelSchema),
   dm: Type.Optional(DiscordDmConfigSchema),
   guilds: Type.Optional(Type.Record(Type.String(), DiscordGuildConfigSchema)),
 });

--- a/pi-gateway/src/core/config.ts
+++ b/pi-gateway/src/core/config.ts
@@ -247,6 +247,7 @@ export interface TelegramGroupConfig {
   requireMention?: boolean;
   role?: string;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
   groupPolicy?: "open" | "disabled" | "allowlist";
   enabled?: boolean;
   allowFrom?: Array<string | number>;
@@ -261,6 +262,7 @@ export interface TelegramTopicConfig {
   requireMention?: boolean;
   role?: string;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
   groupPolicy?: "open" | "disabled" | "allowlist";
   enabled?: boolean;
   allowFrom?: Array<string | number>;
@@ -295,6 +297,7 @@ export interface TelegramAccountConfig {
   messageMode?: "steer" | "follow-up" | "interrupt";
   role?: string;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
   groups?: Record<string, TelegramGroupConfig>;
   mediaMaxMb?: number;
   /** Audio STT configuration */
@@ -336,12 +339,14 @@ export interface DiscordDmConfig {
 export interface DiscordGuildChannelConfig {
   role?: string;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
 }
 
 export interface DiscordGuildConfig {
   requireMention?: boolean;
   role?: string;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
   channels?: Record<string, DiscordGuildChannelConfig>;
 }
 
@@ -351,6 +356,7 @@ export interface DiscordChannelConfig {
   dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
   role?: string;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
   dm?: DiscordDmConfig;
   guilds?: Record<string, DiscordGuildConfig>;
 }

--- a/pi-gateway/src/core/domain/types.ts
+++ b/pi-gateway/src/core/domain/types.ts
@@ -46,6 +46,8 @@ export interface SessionState {
   lastThreadId?: string;
   lastModel?: string;
   lastModelSource?: string;
+  lastThinkingLevel?: string;
+  lastThinkingLevelSource?: string;
 }
 
 /** Inbound message to be processed */

--- a/pi-gateway/src/core/infrastructure/persistence/session-store.ts
+++ b/pi-gateway/src/core/infrastructure/persistence/session-store.ts
@@ -36,6 +36,8 @@ interface PersistedSession {
   lastThreadId?: string;
   lastModel?: string;
   lastModelSource?: string;
+  lastThinkingLevel?: string;
+  lastThinkingLevelSource?: string;
 }
 
 // ============================================================================
@@ -140,6 +142,8 @@ export class SessionStore implements SessionRepository {
           lastThreadId: state.lastThreadId,
           lastModel: state.lastModel,
           lastModelSource: state.lastModelSource,
+          lastThinkingLevel: state.lastThinkingLevel,
+          lastThinkingLevelSource: state.lastThinkingLevelSource,
         };
       }
 
@@ -196,6 +200,8 @@ export class SessionStore implements SessionRepository {
           lastThreadId: data.lastThreadId,
           lastModel: data.lastModel,
           lastModelSource: data.lastModelSource,
+          lastThinkingLevel: data.lastThinkingLevel as any,
+          lastThinkingLevelSource: data.lastThinkingLevelSource,
         });
         count++;
       }

--- a/pi-gateway/src/core/session-router.ts
+++ b/pi-gateway/src/core/session-router.ts
@@ -17,7 +17,7 @@
  */
 
 import type { AgentDefinition, Config } from "./config.ts";
-import type { MessageSource, SessionKey } from "./types.ts";
+import type { MessageSource, SessionKey, ThinkingLevel } from "./types.ts";
 
 const DEFAULT_AGENT_ID = "main";
 const AGENT_ID = "main"; // Legacy fallback, will be removed after v3 migration
@@ -59,6 +59,25 @@ export type ModelSource =
 export interface ModelResolution {
   model: string | null;
   source: ModelSource;
+}
+
+export type ThinkingLevelSource =
+  | "discord.channel"
+  | "discord.guild"
+  | "discord.channel-default"
+  | "telegram.topic"
+  | "telegram.topic-wildcard"
+  | "telegram.group"
+  | "telegram.group-wildcard"
+  | "telegram.account"
+  | "telegram.channel-default"
+  | "channel-default"
+  | "global-agent"
+  | "default";
+
+export interface ThinkingLevelResolution {
+  thinkingLevel: ThinkingLevel | null;
+  source: ThinkingLevelSource;
 }
 
 export type AgentRouteSource = "single-agent" | "binding" | "prefix" | "default";
@@ -281,6 +300,56 @@ export function resolveModelForSession(source: MessageSource, config: Config): s
   return resolveModelForSessionDetailed(source, config).model;
 }
 
+export function resolveThinkingLevelForSessionDetailed(source: MessageSource, config: Config): ThinkingLevelResolution {
+  const { channel, accountId, chatType, chatId, guildId, topicId } = source;
+
+  if (channel === "discord" && config.channels.discord) {
+    const dc = config.channels.discord as any;
+    if (guildId && dc.guilds?.[guildId]) {
+      const guild = dc.guilds[guildId];
+      if (chatId && guild.channels?.[chatId]?.thinkingLevel) {
+        return { thinkingLevel: guild.channels[chatId].thinkingLevel, source: "discord.channel" };
+      }
+      if (guild.thinkingLevel) return { thinkingLevel: guild.thinkingLevel, source: "discord.guild" };
+    }
+    if (dc.thinkingLevel) return { thinkingLevel: dc.thinkingLevel, source: "discord.channel-default" };
+  }
+
+  if (channel === "telegram" && config.channels.telegram) {
+    const tg = config.channels.telegram as any;
+    const accountCfg = accountId ? tg.accounts?.[accountId] : undefined;
+    const groups = accountCfg?.groups ?? tg.groups;
+
+    if (chatType === "group" && topicId) {
+      const groupTopicThinking = groups?.[chatId]?.topics?.[topicId]?.thinkingLevel;
+      if (groupTopicThinking) return { thinkingLevel: groupTopicThinking, source: "telegram.topic" };
+
+      const wildcardGroupTopicThinking = groups?.["*"]?.topics?.[topicId]?.thinkingLevel;
+      if (wildcardGroupTopicThinking) return { thinkingLevel: wildcardGroupTopicThinking, source: "telegram.topic-wildcard" };
+    }
+
+    if (chatType === "group" && groups?.[chatId]?.thinkingLevel) {
+      return { thinkingLevel: groups[chatId].thinkingLevel, source: "telegram.group" };
+    }
+    if (chatType === "group" && groups?.["*"]?.thinkingLevel) {
+      return { thinkingLevel: groups["*"].thinkingLevel, source: "telegram.group-wildcard" };
+    }
+    if (accountCfg?.thinkingLevel) return { thinkingLevel: accountCfg.thinkingLevel, source: "telegram.account" };
+    if (tg.thinkingLevel) return { thinkingLevel: tg.thinkingLevel, source: "telegram.channel-default" };
+  }
+
+  const channelConfig = config.channels[channel];
+  if (channelConfig && typeof channelConfig === "object" && "thinkingLevel" in channelConfig) {
+    return { thinkingLevel: (channelConfig as any).thinkingLevel ?? null, source: "channel-default" };
+  }
+
+  return { thinkingLevel: null, source: "default" };
+}
+
+export function resolveThinkingLevelForSession(source: MessageSource, config: Config): ThinkingLevel | null {
+  return resolveThinkingLevelForSessionDetailed(source, config).thinkingLevel;
+}
+
 function findAgentDefinition(config: Config, agentId?: string): AgentDefinition | null {
   if (!agentId || !config.agents?.list?.length) return null;
   return config.agents.list.find((agent) => agent.id === agentId) ?? null;
@@ -326,6 +395,21 @@ export function resolveModelForSessionAndAgent(
 
   if (config.agent.model) {
     return { model: config.agent.model, source: "global-agent" };
+  }
+
+  return detailed;
+}
+
+export function resolveThinkingLevelForSessionAndAgent(
+  source: MessageSource,
+  config: Config,
+  _agentId?: string,
+): ThinkingLevelResolution {
+  const detailed = resolveThinkingLevelForSessionDetailed(source, config);
+  if (detailed.thinkingLevel) return detailed;
+
+  if (config.agent.thinkingLevel) {
+    return { thinkingLevel: config.agent.thinkingLevel, source: "global-agent" };
   }
 
   return detailed;

--- a/pi-gateway/src/core/session-store.ts
+++ b/pi-gateway/src/core/session-store.ts
@@ -32,6 +32,8 @@ interface PersistedSession {
   lastThreadId?: string;
   lastModel?: string;
   lastModelSource?: string;
+  lastThinkingLevel?: string;
+  lastThinkingLevelSource?: string;
 }
 
 // ============================================================================
@@ -138,6 +140,8 @@ export class SessionStore {
           lastThreadId: s.lastThreadId,
           lastModel: s.lastModel,
           lastModelSource: s.lastModelSource,
+          lastThinkingLevel: s.lastThinkingLevel,
+          lastThinkingLevelSource: s.lastThinkingLevelSource,
         };
       }
 
@@ -195,6 +199,8 @@ export class SessionStore {
           lastThreadId: p.lastThreadId,
           lastModel: p.lastModel,
           lastModelSource: p.lastModelSource,
+          lastThinkingLevel: p.lastThinkingLevel as any,
+          lastThinkingLevelSource: p.lastThinkingLevelSource,
         });
         count++;
       }

--- a/pi-gateway/src/core/tests/unit/model-routing.test.ts
+++ b/pi-gateway/src/core/tests/unit/model-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveModelForSessionAndAgent } from "../../session-router.ts";
+import { resolveModelForSessionAndAgent, resolveThinkingLevelForSessionAndAgent } from "../../session-router.ts";
 import type { MessageSource } from "../../types.ts";
 
 function createBaseConfig(): any {
@@ -130,5 +130,76 @@ describe("model routing", () => {
     const resolved = resolveModelForSessionAndAgent(source, config, "ops");
     expect(resolved.model).toBe("agent/ops");
     expect(resolved.source).toBe("agent.model");
+  });
+
+  test("thinking: telegram topic > group > account > channel > global", () => {
+    const config = createBaseConfig();
+    config.agent.thinkingLevel = "minimal";
+    config.channels.telegram = {
+      enabled: true,
+      thinkingLevel: "low",
+      accounts: {
+        zero: {
+          enabled: true,
+          thinkingLevel: "medium",
+          groups: {
+            "-1001": {
+              thinkingLevel: "high",
+              topics: {
+                "77": { thinkingLevel: "xhigh" },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const source: MessageSource = {
+      channel: "telegram",
+      accountId: "zero",
+      chatType: "group",
+      chatId: "-1001",
+      topicId: "77",
+      senderId: "u1",
+    };
+
+    const resolved = resolveThinkingLevelForSessionAndAgent(source, config);
+    expect(resolved.thinkingLevel).toBe("xhigh");
+    expect(resolved.source).toBe("telegram.topic");
+  });
+
+  test("thinking: same account different groups can route different levels", () => {
+    const config = createBaseConfig();
+    config.agent.thinkingLevel = "off";
+    config.channels.telegram = {
+      enabled: true,
+      accounts: {
+        zero: {
+          enabled: true,
+          groups: {
+            "-100A": { thinkingLevel: "minimal" },
+            "-100B": { thinkingLevel: "high" },
+          },
+        },
+      },
+    };
+
+    const sourceA: MessageSource = {
+      channel: "telegram",
+      accountId: "zero",
+      chatType: "group",
+      chatId: "-100A",
+      senderId: "u1",
+    };
+    const sourceB: MessageSource = {
+      channel: "telegram",
+      accountId: "zero",
+      chatType: "group",
+      chatId: "-100B",
+      senderId: "u1",
+    };
+
+    expect(resolveThinkingLevelForSessionAndAgent(sourceA, config).thinkingLevel).toBe("minimal");
+    expect(resolveThinkingLevelForSessionAndAgent(sourceB, config).thinkingLevel).toBe("high");
   });
 });

--- a/pi-gateway/src/core/types.ts
+++ b/pi-gateway/src/core/types.ts
@@ -222,6 +222,10 @@ export interface SessionState {
   lastModel?: string;
   /** Source of last resolved model */
   lastModelSource?: string;
+  /** Last resolved thinking level for this session turn */
+  lastThinkingLevel?: ThinkingLevel;
+  /** Source of last resolved thinking level */
+  lastThinkingLevelSource?: string;
   /** Auto-compaction in progress (to prevent message race) */
   isCompacting?: boolean;
   /** Set to true after /new (reset) to skip --continue on next spawn */

--- a/pi-gateway/src/gateway/message-pipeline.ts
+++ b/pi-gateway/src/gateway/message-pipeline.ts
@@ -16,7 +16,7 @@
 import type { InboundMessage, SessionKey } from "../core/types.ts";
 import type { GatewayContext } from "./types.ts";
 import type { PrioritizedWork } from "../core/message-queue.ts";
-import { extractAgentIdFromSessionKey, resolveModelForSessionAndAgent, resolveRoleForSessionAndAgent } from "../core/session-router.ts";
+import { extractAgentIdFromSessionKey, resolveModelForSessionAndAgent, resolveRoleForSessionAndAgent, resolveThinkingLevelForSessionAndAgent } from "../core/session-router.ts";
 import { isTuiCommand, tryHandleCommand } from "./command-handler.ts";
 import { getAssistantMessageEvent, getAmePartial } from "../core/rpc-events.ts";
 import { isTransient, classifyError } from "../core/model-health.ts";
@@ -80,6 +80,7 @@ export async function processMessage(
   const agentId = source.agentId ?? extractAgentIdFromSessionKey(sessionKey) ?? undefined;
   const roleResolution = resolveRoleForSessionAndAgent(source, ctx.config, agentId);
   const modelResolution = resolveModelForSessionAndAgent(source, ctx.config, agentId);
+  const thinkingResolution = resolveThinkingLevelForSessionAndAgent(source, ctx.config, agentId);
   const session = ctx.sessions.getOrCreate(sessionKey, {
     role: roleResolution.role,
     isStreaming: false,
@@ -96,6 +97,8 @@ export async function processMessage(
     lastThreadId: source.threadId,
     lastModel: modelResolution.model ?? undefined,
     lastModelSource: modelResolution.source,
+    lastThinkingLevel: thinkingResolution.thinkingLevel ?? undefined,
+    lastThinkingLevelSource: thinkingResolution.source,
   });
   if (isNew) {
     ctx.transcripts.logMeta(sessionKey, "session_created", {
@@ -103,6 +106,8 @@ export async function processMessage(
       roleSource: roleResolution.source,
       model: modelResolution.model,
       modelSource: modelResolution.source,
+      thinkingLevel: thinkingResolution.thinkingLevel,
+      thinkingSource: thinkingResolution.source,
     });
     await ctx.registry.hooks.dispatch("session_start", { sessionKey });
   }
@@ -118,6 +123,8 @@ export async function processMessage(
   session.lastThreadId = source.threadId;
   session.lastModel = modelResolution.model ?? undefined;
   session.lastModelSource = modelResolution.source;
+  session.lastThinkingLevel = thinkingResolution.thinkingLevel ?? undefined;
+  session.lastThinkingLevelSource = thinkingResolution.source;
 
   // Resolve role → capability profile for RPC process
   const role = session.role ?? "default";
@@ -162,6 +169,15 @@ export async function processMessage(
     signature: profile.signature.slice(0, 12),
     capabilities: profile.resourceCounts,
   });
+
+  if (thinkingResolution.thinkingLevel) {
+    try {
+      await rpc.setThinkingLevel(thinkingResolution.thinkingLevel);
+      ctx.log.info(`[thinking-routing] ${sessionKey} level=${thinkingResolution.thinkingLevel} source=${thinkingResolution.source}`);
+    } catch (err: unknown) {
+      ctx.log.warn(`[thinking-routing] failed to apply level=${thinkingResolution.thinkingLevel} source=${thinkingResolution.source}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   if (modelResolution.model) {
     const idx = modelResolution.model.indexOf("/");


### PR DESCRIPTION
## Summary
Implements per-channel model routing so different channels (including same Telegram bot account across different groups/topics) can use different models.

Closes #29

## What’s implemented

### 1) Model config support at routing scopes
Added `model?: string` support to config types + schema for:
- Telegram channel/account/group/topic
- Discord channel/guild/guild-channel

Files:
- `src/core/config.ts`
- `src/core/config-schema.ts`

### 2) Deterministic model resolver
Added model resolution logic in `session-router`:
- `resolveModelForSessionDetailed(...)`
- `resolveModelForSession(...)`
- `resolveModelForSessionAndAgent(...)`

Priority:
1. topic/thread
2. group/channel
3. account
4. channel default
5. generic channel config
6. agent.model
7. global `agent.model`

File:
- `src/core/session-router.ts`

### 3) Apply resolved model during message processing
In `processMessage`:
- Resolve model from inbound source + agent
- Apply via `rpc.setModel(provider, modelId)` before prompting
- Log route decision (`[model-routing] ... source=...`)
- Persist resolved model + source to session state

File:
- `src/gateway/message-pipeline.ts`

### 4) Persist + expose model routing state
Persisted fields:
- `lastModel`
- `lastModelSource`

Updated stores/types:
- `src/core/types.ts`
- `src/core/domain/types.ts`
- `src/core/session-store.ts`
- `src/core/infrastructure/persistence/session-store.ts`

`/api/session/status` now includes:
- `resolvedModel`
- `resolvedModelSource`

File:
- `src/api/session-api.ts`

### 5) Unit tests
Added precedence tests:
- telegram topic > group > account > channel > global
- same account different groups use different models
- discord channel > guild > channel-default > global
- agent-level fallback over global

File:
- `src/core/tests/unit/model-routing.test.ts`

## Validation
Executed:
```bash
bun test src/core/tests/unit/model-routing.test.ts
```
Result: 4 passed.
